### PR TITLE
add space and org fetching after login

### DIFF
--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -10,6 +10,7 @@ import requests
 
 from kibana_cf_auth_proxy.extensions import config
 from kibana_cf_auth_proxy.proxy import proxy_request
+from kibana_cf_auth_proxy import cf
 
 
 def create_app():
@@ -98,6 +99,12 @@ def create_app():
         expiration = now_utc + datetime.timedelta(seconds=response["expires_in"])
         session["access_token_expiration"] = expiration.timestamp()
         session["id_token"] = response["id_token"]
+        session["spaces"] = cf.get_spaces_for_user(
+            session["user_id"], session["access_token"]
+        )
+        session["orgs"] = cf.get_orgs_for_user(
+            session["user_id"], session["access_token"]
+        )
         return "logged in"
 
     @app.route("/", defaults={"path": ""})

--- a/kibana_cf_auth_proxy/cf.py
+++ b/kibana_cf_auth_proxy/cf.py
@@ -1,0 +1,34 @@
+import requests
+
+from kibana_cf_auth_proxy.extensions import config
+
+
+def iterate_cf_resource(session, first_request):
+    """
+    iterates over a v3-style, paginated resource, returning the full list of the resources
+    """
+    resources = []
+    data = session.get(first_request).json()
+    resources.extend(data["resources"])
+    while data["pagination"]["next"] is not None:
+        data = session.get(data["pagination"]["next"]["href"]).json()
+        resources.extend(data["resources"])
+    return resources
+
+
+def get_spaces_for_user(user_id, token):
+    with requests.Session() as s:
+        s.headers["Authorization"] = f"Bearer {token}"
+        url = f"{config.CF_URL}v3/roles?user_guids={user_id}&types={','.join(config.PERMITTED_SPACE_ROLES)}"
+        resources = iterate_cf_resource(s, url)
+    spaces = [r["relationships"]["space"]["data"]["guid"] for r in resources]
+    return spaces
+
+
+def get_orgs_for_user(user_id, token):
+    with requests.Session() as s:
+        s.headers["Authorization"] = f"Bearer {token}"
+        url = f"{config.CF_URL}v3/roles?user_guids={user_id}&types={','.join(config.PERMITTED_ORG_ROLES)}"
+        resources = iterate_cf_resource(s, url)
+    orgs = [r["relationships"]["organization"]["data"]["guid"] for r in resources]
+    return orgs

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -11,6 +11,12 @@ class Config:
     def __init__(self):
         self.env_parser = Env()
         self.PORT = self.env_parser.int("PORT", 8080)
+        self.PERMITTED_SPACE_ROLES = self.env_parser.list(
+            "PERMITTED_SPACE_ROLES", ["space_developer", "space_manager"]
+        )
+        self.PERMITTED_ORG_ROLES = self.env_parser.list(
+            "PERMITTED_ORG_ROLES", ["org_manager"]
+        )
 
 
 class LocalConfig(Config):
@@ -20,6 +26,7 @@ class LocalConfig(Config):
         self.DEBUG = True
         self.KIBANA_URL = "mock://kibana/"
         self.SESSION_TYPE = "filesystem"
+        self.CF_URL = "mock://cf/"
         self.UAA_AUTH_URL = "mock://uaa/authorize"
         self.UAA_TOKEN_URL = "mock://uaa/token"
         self.UAA_REFRESH_URL = "mock://uaa/refresh"
@@ -41,6 +48,7 @@ class AppConfig(Config):
         self.SESSION_TYPE = "null"
         self.SESSION_COOKIE_SECURE = True
 
+        self.CF_URL = self.env_parser("CF_URL")
         self.UAA_AUTH_URL = self.env_parser.str("UAA_AUTH_URL")
         self.UAA_TOKEN_URL = self.env_parser.str("UAA_TOKEN_URL")
         self.UAA_REFRESH_URL = self.env_parser.str("UAA_REFRESH_URL")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,3 +43,109 @@ def authenticated_client(client):
     with client.session_transaction() as s:
         s["user_id"] = "me"
     yield client
+
+
+@pytest.fixture()
+def simple_space_response():
+    return """
+  {
+   "pagination": {
+      "total_results": 1,
+      "total_pages": 1,
+      "first": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+      },
+      "last": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+      },
+      "next": null,
+      "previous": null
+   },
+   "resources": [
+      {
+         "guid": "role-guid-1",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "space_developer",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-guid-1"
+               }
+            },
+            "organization": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "mock://cf/v3/roles/role-guid-1"
+            },
+            "user": {
+               "href": "mock://cf/v3/users/a-user-guid"
+            },
+            "space": {
+               "href": "mock://cf/v3/spaces/space-guid-1"
+            }
+         }
+        }
+      ]
+    } """
+
+
+@pytest.fixture()
+def simple_org_response():
+    return """
+  {
+   "pagination": {
+      "total_results": 1,
+      "total_pages": 1,
+      "first": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=org_manager&user_guids=a-user-guid"
+      },
+      "last": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid"
+      },
+      "next": null,
+      "previous": null
+   },
+   "resources": [
+      {
+         "guid": "role-guid-1",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "space_developer",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "space": {
+               "data": null
+            },
+            "organization": {
+               "data": {
+                  "guid": "org-guid-1"
+               }
+            }
+         },
+         "links": {
+            "self": {
+               "href": "mock://cf/v3/roles/role-guid-1"
+            },
+            "user": {
+               "href": "mock://cf/v3/users/a-user-guid"
+            },
+            "organization": {
+               "href": "mock://cf/v3/spaces/org-guid-1"
+            }
+         }
+        }
+      ]
+    } """

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,9 +1,10 @@
+import pickle
+import time
+
 from urllib import parse
 import pytest
 import requests_mock
-import time
 import flask
-import pickle
 
 
 def test_app_pongs(client):

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -1,0 +1,239 @@
+import pytest
+import requests_mock
+
+from kibana_cf_auth_proxy import cf
+
+
+def test_gets_spaces():
+    with requests_mock.Mocker() as m:
+        response_1 = """
+  {
+   "pagination": {
+      "total_results": 2,
+      "total_pages": 2,
+      "first": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+      },
+      "last": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+      },
+      "next": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+      },
+      "previous": null
+   },
+   "resources": [
+      {
+         "guid": "role-guid-1",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "space_developer",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-guid-1"
+               }
+            },
+            "organization": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "mock://cf/v3/roles/role-guid-1"
+            },
+            "user": {
+               "href": "mock://cf/v3/users/a-user-guid"
+            },
+            "space": {
+               "href": "mock://cf/v3/spaces/space-guid-1"
+            }
+         }
+        }
+      ]
+    } """
+        response_2 = """
+  {
+   "pagination": {
+      "total_results": 2,
+      "total_pages": 2,
+      "first": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+      },
+      "last": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+      },
+      "next": null,
+      "previous": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+      }
+   },
+   "resources": [
+      {
+         "guid": "role-guid-2",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "space_developer",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-guid-2"
+               }
+            },
+            "organization": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "mock://cf/v3/roles/role-guid-2"
+            },
+            "user": {
+               "href": "mock://cf/v3/users/a-user-guid"
+            },
+            "space": {
+               "href": "mock://cf/v3/spaces/space-guid-2"
+            }
+         }
+        }
+      ]
+    }
+    """
+        m.get(
+            "mock://cf/v3/roles?user_guids=a-user-id&types=space_developer,space_manager",
+            text=response_1,
+        )
+        m.get(
+            "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid",
+            text=response_2,
+        )
+        assert sorted(cf.get_spaces_for_user("a-user-id", "a_token")) == sorted(
+            ["space-guid-1", "space-guid-2"]
+        )
+
+
+def test_gets_roles():
+    with requests_mock.Mocker() as m:
+        response_1 = """
+  {
+   "pagination": {
+      "total_results": 2,
+      "total_pages": 2,
+      "first": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=org_manager&user_guids=a-user-guid"
+      },
+      "last": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid"
+      },
+      "next": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid"
+      },
+      "previous": null
+   },
+   "resources": [
+      {
+         "guid": "role-guid-1",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "org_manager",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "organization": {
+               "data": {
+                  "guid": "org-guid-1"
+               }
+            },
+            "space": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "mock://cf/v3/roles/role-guid-1"
+            },
+            "user": {
+               "href": "mock://cf/v3/users/a-user-guid"
+            },
+            "organization": {
+               "href": "mock://cf/v3/organization/org-guid-1"
+            }
+         }
+        }
+      ]
+    } """
+        response_2 = """
+  {
+   "pagination": {
+      "total_results": 2,
+      "total_pages": 2,
+      "first": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=org_manager&user_guids=a-user-guid"
+      },
+      "last": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid"
+      },
+      "next": null,
+      "previous": {
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=org_manager&user_guids=a-user-guid"
+      }
+   },
+   "resources": [
+      {
+         "guid": "role-guid-2",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "org_manager",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "organization": {
+               "data": {
+                  "guid": "org-guid-2"
+               }
+            },
+            "space": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "mock://cf/v3/roles/role-guid-2"
+            },
+            "user": {
+               "href": "mock://cf/v3/users/a-user-guid"
+            },
+            "organization": {
+               "href": "mock://cf/v3/organizations/org-guid-2"
+            }
+         }
+        }
+      ]
+    }
+    """
+        m.get(
+            "mock://cf/v3/roles?user_guids=a-user-id&types=org_manager", text=response_1
+        )
+        m.get(
+            "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid",
+            text=response_2,
+        )
+        assert sorted(cf.get_orgs_for_user("a-user-id", "a_token")) == sorted(
+            ["org-guid-1", "org-guid-2"]
+        )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,10 +11,13 @@ def test_config_loads(monkeypatch):
     assert config.UAA_AUTH_URL == "mock://uaa/authorize"
     assert config.UAA_TOKEN_URL == "mock://uaa/token"
     assert config.UAA_REFRESH_URL == "mock://uaa/refresh"
+    assert config.CF_URL == "mock://cf/"
     assert config.UAA_CLIENT_ID == "EXAMPLE"
     assert config.UAA_CLIENT_SECRET == "example"
     assert config.SECRET_KEY == "CHANGEME"
     assert config.PERMANENT_SESSION_LIFETIME == 120
+    assert config.PERMITTED_SPACE_ROLES == ["space_developer", "space_manager"]
+    assert config.PERMITTED_ORG_ROLES == ["org_manager"]
 
 
 @pytest.mark.parametrize(
@@ -27,6 +30,7 @@ def test_prod_config(monkeypatch, kibana_url):
     monkeypatch.setenv("UAA_AUTH_URL", "https://uaa.example.com/authorize")
     monkeypatch.setenv("UAA_TOKEN_URL", "https://uaa.example.com/token")
     monkeypatch.setenv("UAA_REFRESH_URL", "https://uaa.example.com/refresh")
+    monkeypatch.setenv("CF_URL", "https://api.example.com/")
     monkeypatch.setenv("UAA_CLIENT_ID", "feedabee")
     monkeypatch.setenv("UAA_CLIENT_SECRET", "CHANGEME")
     monkeypatch.setenv("SECRET_KEY", "changeme")
@@ -41,5 +45,8 @@ def test_prod_config(monkeypatch, kibana_url):
     assert config.UAA_REFRESH_URL == "https://uaa.example.com/refresh"
     assert config.UAA_CLIENT_ID == "feedabee"
     assert config.UAA_CLIENT_SECRET == "CHANGEME"
+    assert config.CF_URL == "https://api.example.com/"
     assert config.SECRET_KEY == "changeme"
     assert config.PERMANENT_SESSION_LIFETIME == 3600
+    assert config.PERMITTED_SPACE_ROLES == ["space_developer", "space_manager"]
+    assert config.PERMITTED_ORG_ROLES == ["org_manager"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fetch spaces and orgs when logging in
- fixes #3 

I'm not sure yet whether it'll be better to feed the orgs and spaces to ODfE, or whether we should get all the spaces for all the orgs instead. Getting the spaces seems like it could cause a really bad login lag for users with lots of orgs, whereas sending orgs and spaces to ODfE will make all our queries more complex (both to read/write for humans, and to execute for Elasticsearch)

I'm also not sure whether we can/should use the user's token to get their user info, or if we should use a dedicated, app-specific token.

## Security considerations

Continuing process on getting better authn/authz for Kibana