### PR TITLE
Real local dev

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -35,6 +35,21 @@ jobs:
         run:
           path: src/ci/test.sh
 
+- name: build-test-images
+  - put: dev-docker-elasticsearch-image
+    params:
+      build: src/docker/images/elasticsearch
+      dockerfile: src/docker/images/elasticsearch/dockerfile
+      tag_as_latest: true
+      cache: true
+
+  - put: dev-docker-kibana-image
+    params:
+      build: src/docker/images/kibana
+      dockerfile: src/docker/images/kibana/dockerfile
+      tag_as_latest: true
+      cache: true
+
 ############################
 #  RESOURCES
 
@@ -56,6 +71,23 @@ resources:
     uri: https://github.com/cloud-gov/((name))
     branch: ((git-branch))
 
+- name: dev-elasticsearch-image
+  type: docker-image
+  icon: docker
+  source:
+    email: ((docker-email))
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: ((docker-image-elasticsearch-dev))
+
+- name: dev-kibana-image
+  type: docker-image
+  icon: docker
+  source:
+    email: ((docker-email))
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: ((docker-image-kibana-dev))
 
 ############################
 #  RESOURCE TYPES

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -36,14 +36,14 @@ jobs:
           path: src/ci/test.sh
 
 - name: build-test-images
-  - put: dev-docker-elasticsearch-image
+  - put: dev-elasticsearch-image
     params:
       build: src/docker/images/elasticsearch
       dockerfile: src/docker/images/elasticsearch/dockerfile
       tag_as_latest: true
       cache: true
 
-  - put: dev-docker-kibana-image
+  - put: dev-kibana-image
     params:
       build: src/docker/images/kibana
       dockerfile: src/docker/images/kibana/dockerfile

--- a/dev
+++ b/dev
@@ -118,15 +118,9 @@ main() {
     cluster)
       
       pushd docker
-      docker-compose down
-      docker-compose build
-      docker-compose up -d
+        docker-compose up --force-recreate --build -d
       popd
 
-      set -o allexport; source ${dir}/.env; set +o allexport
-      export FLASK_APP="kibana_cf_auth_proxy.app:create_app()"
-
-      ${python} -m flask run -p ${PORT}
       ;;
     destroy-cluster)
       pushd docker

--- a/dev
+++ b/dev
@@ -115,6 +115,19 @@ main() {
       
       ${python} -m flask run -p ${PORT}
       ;;
+    cluster)
+      
+      pushd docker
+      docker-compose down
+      docker-compose build
+      docker-compose up -d
+      popd
+
+      set -o allexport; source ${dir}/.env; set +o allexport
+      export FLASK_APP="kibana_cf_auth_proxy.app:create_app()"
+
+      ${python} -m flask run -p ${PORT}
+      ;;
     watch-test|watch-tests)
       watch_tests
       ;;

--- a/dev
+++ b/dev
@@ -128,6 +128,11 @@ main() {
 
       ${python} -m flask run -p ${PORT}
       ;;
+    destroy-cluster)
+      pushd docker
+        docker-compose down
+      popd
+      ;;
     watch-test|watch-tests)
       watch_tests
       ;;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,73 @@
+version: '3'
+services:
+  odfe-node1:
+    build: ./elasticsearch
+    container_name: odfe-node1
+    environment:
+      - cluster.name=odfe-cluster
+      - node.name=odfe-node1
+      - discovery.seed_hosts=odfe-node1,odfe-node2
+      - cluster.initial_master_nodes=odfe-node1,odfe-node2
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "ES_JAVA_OPTS=-Xms2048m -Xmx2048m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - opendistro_security.audit.type=debug
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the Elasticsearch user, set to at least 65536 on modern systems
+        hard: 65536
+    volumes:
+      - odfe-data1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - odfe-net
+  odfe-node2:
+    build: ./elasticsearch
+    container_name: odfe-node2
+    environment:
+      - cluster.name=odfe-cluster
+      - node.name=odfe-node2
+      - discovery.seed_hosts=odfe-node1,odfe-node2
+      - cluster.initial_master_nodes=odfe-node1,odfe-node2
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms2048m -Xmx2048m"
+      - opendistro_security.audit.type=debug
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - odfe-data2:/usr/share/elasticsearch/data
+    networks:
+      - odfe-net
+  kibana:
+    build: ./kibana
+    container_name: odfe-kibana
+    ports:
+      - 5601:5601
+    expose:
+      - "5601"
+    environment:
+      ELASTICSEARCH_URL: https://odfe-node1:9200
+      ELASTICSEARCH_HOSTS: https://odfe-node1:9200
+      elasticsearch.requestHeadersWhitelist: "securitytenant,Authorization,x-forwarded-for,x-proxy-user,x-proxy-roles"
+      openditsro.security.auth_type: "proxy"
+      opendistro.security.proxycache.user_header: "x-proxy-user"
+      opendistro.security.proxycache.roles_header: "x-proxy-roles"
+
+    networks:
+      - odfe-net
+    volumes: []
+
+volumes:
+  odfe-data1:
+  odfe-data2:
+
+networks:
+  odfe-net:

--- a/docker/elasticsearch/config.yml
+++ b/docker/elasticsearch/config.yml
@@ -1,0 +1,35 @@
+---
+_meta:
+  type: "config"
+  config_version: 2
+
+config:
+  dynamic:
+    http:
+      xff:
+        enabled: true
+        internalProxies: ".*"
+        remoteIpHeader: "x-forwarded-for"
+    authc:
+      basic_internal_auth_domain:
+        description: "Authenticate via HTTP Basic against internal users database"
+        http_enabled: true
+        transport_enabled: true
+        order: 4
+        http_authenticator:
+          type: basic
+          challenge: true
+        authentication_backend:
+          type: intern
+      proxy_auth_domain:
+        http_enabled: true
+        transport_enabled: true
+        order: 0
+        http_authenticator:
+          type: proxy
+          challenge: false
+          config:
+            user_header: "x-proxy-user"
+            roles_header: "x-proxy-roles"
+        authentication_backend:
+          type: noop

--- a/docker/elasticsearch/dockerfile
+++ b/docker/elasticsearch/dockerfile
@@ -1,0 +1,30 @@
+FROM amazon/opendistro-for-elasticsearch:1.12.0 as ODFE
+
+# ok, this is a little weird.
+# we're building this image to run on Cloud Foundry, where we can
+# only have one port exposed. The upstream exposes more than one, 
+# and docker doesn't provide a direct method to override it.
+# so, we're using the ODfE image as a "builder" and then copying
+# everything into scratch, which is a blank image ¯\_(ツ)_/¯
+FROM scratch
+
+COPY --from=ODFE / /
+
+# copying the files doesn't copy the metadata - that's the whole point
+# these are the same as the upstream
+WORKDIR /usr/share/elasticsearch
+ENV JAVA_HOME /opt/jdk
+ENV PATH $PATH:$JAVA_HOME/bin
+ENV ELASTIC_CONTAINER true
+USER 1000
+
+# add the new stuff
+COPY config.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/config.yml
+COPY roles.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml
+COPY roles_mapping.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles_mapping.yml
+
+EXPOSE 9200
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+# Dummy overridable parameter parsed by entrypoint
+CMD ["eswrapper"]

--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -1,0 +1,20 @@
+---
+cf_user:
+  reserved: false
+  hidden: false
+  cluster_permissions:
+  - "read"
+  - "cluster:monitor/nodes/stats"
+  - "cluster:monitor/task/get"
+  index_permissions:
+  - index_patterns:
+    - "logs-app-*"
+    dls: "{\"bool\": {\"should\": [{\"terms\": { \"@cf.space_id\": [\"$attr.proxy.space_ids\"] }}, {\"terms\": {\"@cf.org_id\": [\"$attr.proxy.org_ids\"]}}]}}"
+    fls:
+    allowed_actions:
+    - "read"
+  tenant_permissions: []
+  static: false
+_meta:
+  type: "roles"
+  config_version: 2

--- a/docker/elasticsearch/roles_mapping.yml
+++ b/docker/elasticsearch/roles_mapping.yml
@@ -1,0 +1,16 @@
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+cf_user:
+  reserved: true
+  hidden: false
+  backend_roles:
+  - "user"
+  hosts: []
+  users: []
+  and_backend_roles: []
+  description: "Maps admin to all_access"
+kibana_server:
+  reserved: true
+  users:
+  - "kibanaserver"

--- a/docker/kibana/dockerfile
+++ b/docker/kibana/dockerfile
@@ -1,0 +1,17 @@
+FROM amazon/opendistro-for-elasticsearch-kibana:1.12.0 AS kibana
+
+
+FROM scratch
+
+COPY --from=kibana / /
+
+WORKDIR /usr/share/kibana
+
+ENV PATH=/usr/share/kibana/bin:$PATH
+USER 1000
+
+EXPOSE 5601
+
+COPY kibana.yml /usr/share/kibana/config/kibana.yml
+
+CMD ["/usr/local/bin/kibana-docker"]

--- a/docker/kibana/kibana.yml
+++ b/docker/kibana/kibana.yml
@@ -1,0 +1,23 @@
+server.name: kibana
+server.host: "0"
+elasticsearch.hosts: https://localhost:9200
+elasticsearch.ssl.verificationMode: none
+elasticsearch.username: kibanaserver
+elasticsearch.password: kibanaserver
+
+opendistro_security.multitenancy.enabled: true
+opendistro_security.multitenancy.tenants.preferred: ["Private", "Global"]
+opendistro_security.readonly_mode.roles: ["kibana_read_only"]
+
+# Use this setting if you are running kibana without https
+opendistro_security.cookie.secure: false
+
+newsfeed.enabled: false
+telemetry.optIn: false
+telemetry.enabled: false
+security.showInsecureClusterWarning: false
+elasticsearch.requestHeadersWhitelist: ["securitytenant","Authorization","x-forwarded-for","x-proxy-user","x-proxy-roles"]
+
+opendistro_security.auth.type: "proxy"
+opendistro_security.proxycache.user_header: "x-proxy-user"
+opendistro_security.proxycache.roles_header: "x-proxy-roles"

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -128,7 +128,7 @@ def create_app():
         if session.get("user_id") is None and path not in allowed_paths:
             return redirect_to_auth()
 
-        forbidden_headers = {"host", "x-proxy-user", "x-proxy-ext-spaces"}
+        forbidden_headers = {"host", "x-proxy-user", "x-proxy-ext-space-ids"}
         url = request.url.replace(request.host_url, config.KIBANA_URL)
         headers = {
             k: v

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -142,7 +142,7 @@ def create_app():
             headers["x-proxy-user"] = session["user_id"]
             headers["x-proxy-roles"] = "user"
         
-        # next line is for local testing only. If it shows up in a PR, decline it!
+        # TODO: add x-forwarded-for functionality
         headers["x-forwarded-for"] = "127.0.0.1"
 
         return proxy_request(

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -17,6 +17,7 @@ class Config:
         self.PERMITTED_ORG_ROLES = self.env_parser.list(
             "PERMITTED_ORG_ROLES", ["org_manager"]
         )
+        self.SESSION_COOKIE_NAME = "cfsession"
 
 
 class UnitConfig(Config):

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -49,6 +49,7 @@ class LocalConfig(Config):
 
         self.SESSION_REFRESH_EACH_REQUEST = True
 
+        self.CF_URL = self.env_parser("CF_URL")
         self.UAA_AUTH_URL = self.env_parser.str("UAA_AUTH_URL")
         self.UAA_TOKEN_URL = self.env_parser.str("UAA_TOKEN_URL")
         self.UAA_CLIENT_ID = self.env_parser.str("UAA_CLIENT_ID")

--- a/kibana_cf_auth_proxy/proxy.py
+++ b/kibana_cf_auth_proxy/proxy.py
@@ -24,6 +24,11 @@ def proxy_request(url, headers, data, cookies, method):
         for (name, value) in resp.raw.headers.items()
         if name.lower() not in excluded_headers
     ]
+    kwargs = {}
+    if resp.raw.headers.get("content-encoding") == "br":
+        headers.append(("content-encoding", "br"),)
+    if "content-type" in resp.headers:
+        kwargs["content_type"] = resp.headers["content-type"]
 
-    response = Response(resp.content, resp.status_code, headers)
+    response = Response(resp.content, resp.status_code, headers, **kwargs)
     return response


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add a local cluster for testing. This uses docker-compose to spin up a 2-node ODfE elasticsearch cluster and a kibana instance.
- Add pipeline steps for building and pushing test instances. This will allow us to push these containers as CF apps, which is how I plan to run the e2e tests
- Fix bugs identified while testing
  - handle br compression, which flask doesn't understand
  - allow all methods on proxy route so Kibana/Elasticsearch can decide what to do with them
  - allow unauthenticated access to one weird path that browsers don't send cookies to somehow?????
  - rename session cookie
  - configure cf url

## Security considerations

- There is some risk in this image - it has hard-coded passwords, but the image is made only for testing and its name (hopefully) makes that clear
- The bypassed path is just favicons, but it feels really weird that it doesn't send cookies
- Allowing all methods is kind of scary, but we're just proxying them, and it's required because Kibana actually makes use of some/all of the verbs 