### PR TITLE
split manifests to make concourse happier

### DIFF
--- a/cf/README.md
+++ b/cf/README.md
@@ -1,0 +1,9 @@
+These manifests are for a Cloud Foundry-based cluster with 1 elasticsearch,
+1 redis, and 1 auth-proxy instance.
+
+These are separate manifests because the concourse cf resource doesn't
+work with multiple apps in a manifest.
+
+# SECURITY NOTICE
+This cluster is totally insecure and non-durable. It should only be used
+for testing the proxy and should NEVER have any sensitive or important data.

--- a/cf/elasticsearch-manifest.yml
+++ b/cf/elasticsearch-manifest.yml
@@ -1,0 +1,22 @@
+---
+###########################################################
+# NOTE: this cluster is totally insecure and non-durable. #
+# It should only be used for testing the proxy and should #
+# NEVER have any sensitive or important data.             #
+###########################################################
+
+version: 1
+applications:
+- name: elasticsearch
+  memory: 3G
+  instances: 1
+  disk_quota: 2G
+  routes:
+    - route: odfe-test.apps.internal
+  docker:
+    image: cloudgovoperations/test-elasticsearch-odfe:latest
+  env:
+    "discovery.type": single-node
+    "node.name": odfe-node1
+    "ES_JAVA_OPTS": "-Xms2048m -Xmx2048m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+    "opendistro_security.audit.type": debug

--- a/cf/kibana-manifest.yml
+++ b/cf/kibana-manifest.yml
@@ -7,19 +7,6 @@
 
 version: 1
 applications:
-- name: elasticsearch
-  memory: 3G
-  instances: 1
-  disk_quota: 2G
-  routes:
-    - route: odfe-test.apps.internal
-  docker:
-    image: cloudgovoperations/test-elasticsearch-odfe:latest
-  env:
-    "discovery.type": single-node
-    "node.name": odfe-node1
-    "ES_JAVA_OPTS": "-Xms2048m -Xmx2048m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
-    "opendistro_security.audit.type": debug
 - name: kibana
   memory: 1G
   instances: 1
@@ -34,20 +21,3 @@ applications:
       "opendistro.security.proxycache.roles_header": "x-proxy-roles"
   routes:
     - route: kbn-test.apps.internal
-- name: auth-proxy
-  health_check_type: port
-  buildpacks:
-    - python_buildpack
-  routes:
-    - route: ((public_route))
-  env:
-    FLASK_ENV: local
-    KIBANA_URL: http://kbn-test.apps.internal:5601
-
-    CF_URL: ((cf_url))
-    UAA_AUTH_URL: ((uaa_auth_url))
-    UAA_TOKEN_URL: ((uaa_token_url))
-    UAA_CLIENT_ID: ((uaa_client_id))
-    UAA_CLIENT_SECRET: ((uaa_client_secret))
-    SECRET_KEY: ((secret_key))
-    SESSION_LIFETIME: ((session_lifetime))

--- a/cf/proxy-manifest.yml
+++ b/cf/proxy-manifest.yml
@@ -1,0 +1,26 @@
+---
+###########################################################
+# NOTE: this cluster is totally insecure and non-durable. #
+# It should only be used for testing the proxy and should #
+# NEVER have any sensitive or important data.             #
+###########################################################
+
+version: 1
+applications:
+- name: auth-proxy
+  health_check_type: port
+  buildpacks:
+    - python_buildpack
+  routes:
+    - route: ((public_route))
+  env:
+    FLASK_ENV: local
+    KIBANA_URL: http://kbn-test.apps.internal:5601
+
+    CF_URL: ((cf_url))
+    UAA_AUTH_URL: ((uaa_auth_url))
+    UAA_TOKEN_URL: ((uaa_token_url))
+    UAA_CLIENT_ID: ((uaa_client_id))
+    UAA_CLIENT_SECRET: ((uaa_client_secret))
+    SECRET_KEY: ((secret_key))
+    SESSION_LIFETIME: ((session_lifetime))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -66,8 +66,17 @@ jobs:
     - put: cf-dev
       params:
         path: src
-        manifest: src/cf/manifest.yml
-        show_app_log: true
+        manifest: src/cf/elasticsearch-manifest.yml
+    
+    - put: cf-dev
+      params:
+        path: src
+        manifest: src/cf/kibana-manifest.yml
+    
+    - put: cf-dev
+      params:
+        path: src
+        manifest: src/cf/proxy-manifest.yml
         vars:
           cf_url: ((dev-cf-url))
           uaa_auth_url: ((dev-uaa-auth-url))
@@ -75,7 +84,7 @@ jobs:
           uaa_client_id: ((dev-uaa-client-id))
           uaa_client_secret: ((dev-uaa-client-secret))
           secret_key: ((dev-secret-key))
-          session_lifetime: 3600
+          session_lifetime: "3600"
           public_route: ((dev-public-url))
 
     - task: update-networking


### PR DESCRIPTION
## Changes proposed in this pull request:

- split manifests to make concourse happier
- use a string for session timeout, because concourse hates numbers

## Security considerations

None