### PR TITLE
backport permitted role change into tests

### DIFF
--- a/tests/unit/test_authn.py
+++ b/tests/unit/test_authn.py
@@ -56,11 +56,11 @@ def test_callback_happy_path(client, simple_org_response, simple_space_response)
             text=json.dumps(body),
         )
         m.get(
-            "mock://cf/v3/roles?user_guids=test_user&types=space_developer,space_manager",
+            "mock://cf/v3/roles?user_guids=test_user&types=space_developer,space_manager,space_auditor",
             text=simple_space_response,
         )
         m.get(
-            "mock://cf/v3/roles?user_guids=test_user&types=org_manager",
+            "mock://cf/v3/roles?user_guids=test_user&types=organization_manager,organization_auditor",
             text=simple_org_response,
         )
         client.get(f"/cb?code=1234&state={csrf}")

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -15,10 +15,10 @@ def test_gets_spaces():
          "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "next": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "previous": null
    },
@@ -63,14 +63,14 @@ def test_gets_spaces():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "next": null,
       "previous": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       }
    },
    "resources": [
@@ -110,11 +110,11 @@ def test_gets_spaces():
     }
     """
         m.get(
-            "mock://cf/v3/roles?user_guids=a-user-id&types=space_developer,space_manager",
+            "mock://cf/v3/roles?user_guids=a-user-id&types=space_developer,space_manager,space_auditor",
             text=response_1,
         )
         m.get(
-            "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid",
+            "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid",
             text=response_2,
         )
         assert sorted(cf.get_spaces_for_user("a-user-id", "a_token")) == sorted(
@@ -130,13 +130,13 @@ def test_gets_roles():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=org_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
       },
       "next": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
       },
       "previous": null
    },
@@ -181,14 +181,14 @@ def test_gets_roles():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=org_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
       },
       "next": null,
       "previous": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=org_manager&user_guids=a-user-guid"
+         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
       }
    },
    "resources": [
@@ -228,10 +228,11 @@ def test_gets_roles():
     }
     """
         m.get(
-            "mock://cf/v3/roles?user_guids=a-user-id&types=org_manager", text=response_1
+            "mock://cf/v3/roles?user_guids=a-user-id&types=organization_manager,organization_auditor",
+            text=response_1,
         )
         m.get(
-            "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid",
+            "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid",
             text=response_2,
         )
         assert sorted(cf.get_orgs_for_user("a-user-id", "a_token")) == sorted(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,8 +15,15 @@ def test_config_loads(monkeypatch):
     assert config.UAA_CLIENT_SECRET == "example"
     assert config.SECRET_KEY == "CHANGEME"
     assert config.PERMANENT_SESSION_LIFETIME == 120
-    assert config.PERMITTED_SPACE_ROLES == ["space_developer", "space_manager"]
-    assert config.PERMITTED_ORG_ROLES == ["org_manager"]
+    assert config.PERMITTED_SPACE_ROLES == [
+        "space_developer",
+        "space_manager",
+        "space_auditor",
+    ]
+    assert config.PERMITTED_ORG_ROLES == [
+        "organization_manager",
+        "organization_auditor",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -73,5 +80,12 @@ def test_prod_config(monkeypatch, kibana_url):
     assert config.CF_URL == "https://api.example.com/"
     assert config.SECRET_KEY == "changeme"
     assert config.PERMANENT_SESSION_LIFETIME == 3600
-    assert config.PERMITTED_SPACE_ROLES == ["space_developer", "space_manager"]
-    assert config.PERMITTED_ORG_ROLES == ["org_manager"]
+    assert config.PERMITTED_SPACE_ROLES == [
+        "space_developer",
+        "space_manager",
+        "space_auditor",
+    ]
+    assert config.PERMITTED_ORG_ROLES == [
+        "organization_manager",
+        "organization_auditor",
+    ]


### PR DESCRIPTION
## Changes proposed in this pull request:

- backport permitted role change into tests. When working on the e2e tests, I changed the default config for the permitted roles to correct the names and align the permissions. I neglected to update (or run :( ) the unit tests at the time. This fixes them

All of these changes should be one of:
- [space_developer,space_manager] -> [space_developer,space_manager,space_auditor]
- [org_manager] -> [organization_manager,organization_auditor]

## Security considerations

None