### PR TITLE
fix path for bandit

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 shopt -s inherit_errexit
 
 src/dev set-up-environment
-bandit -r kibana_cf_auth_proxy
+src/venv/bin/bandit -r kibana_cf_auth_proxy
 src/dev test


### PR DESCRIPTION
## Changes proposed in this pull request:

- since we aren't activating the venv, we need to provide a path to the `bandit` binary to call it

## Security considerations

None