### PR TITLE
Update roles header based on CF admin status

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -11,7 +11,6 @@ CF_API_URL=https://api.example.cloud.gov/ # make sure to include trailing slash!
 KIBANA_URL=https://kibana.example.com
 UAA_AUTH_URL=https://login.example.com/oauth/authorize
 UAA_BASE_URL=https://uaa.example.com/ # make sure to include trailing slash!
-UAA_TOKEN_URL=https://uaa.example.com/oauth/token
 UAA_CLIENT_ID=FEEDABEE
 UAA_CLIENT_SECRET=CHANGEME
 SECRET_KEY=changeme

--- a/.env-sample
+++ b/.env-sample
@@ -10,6 +10,7 @@ PORT=8080
 CF_API_URL=https://api.example.cloud.gov/ # make sure to include trailing slash!
 KIBANA_URL=https://kibana.example.com
 UAA_AUTH_URL=https://login.example.com/oauth/authorize
+UAA_BASE_URL=https://uaa.example.com/ # make sure to include trailing slash!
 UAA_TOKEN_URL=https://uaa.example.com/oauth/token
 UAA_CLIENT_ID=FEEDABEE
 UAA_CLIENT_SECRET=CHANGEME

--- a/.env-sample
+++ b/.env-sample
@@ -14,3 +14,4 @@ UAA_BASE_URL=https://uaa.example.com/ # make sure to include trailing slash!
 UAA_CLIENT_ID=FEEDABEE
 UAA_CLIENT_SECRET=CHANGEME
 SECRET_KEY=changeme
+CF_ADMIN_GROUP_NAME="<cf-group-name>"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ where `<my_url>` is the local host/port on your machine for this app (default `h
 
 ```shell
 uaac client add <my_client_name> \
-   --authorized_grant_types authorization_code,refresh_token \
+   --authorized_grant_types authorization_code,refresh_token,client_credentials \
    --authorities scim.read \
    --scope "cloud_controller.read,openid,scim.read" \
    -s <my_client_secret> \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The following environment variables are required:
 - `KIBANA_URL` - this is the url of the proxied kibana instance
 - `UAA_AUTH_URL` - where to send your users for authentication. Probably looks like `https://login.<domain>/oauth/authorize`
 - `UAA_BASE_URL` - base URL for app where your client can exchange codes and refresh tokens for tokens. Probably looks like `https://uaa.<domain>/`.
-- `UAA_TOKEN_URL` - where your client can exchange codes and refresh tokens for tokens. Probably looks like `https://uaa.<domain>/token`
 - `UAA_CLIENT_ID` - the client ID of your uaa clinet
 - `UAA_CLIENT_SECRET` - the client secret for your uaa client
 - `SECRET_KEY` - the key used for cookie signing

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ The following environment variables are required:
 - `FLASK_ENV` - set to `unit` for tests, `local` for development, `production` for production
 - `KIBANA_URL` - this is the url of the proxied kibana instance
 - `UAA_AUTH_URL` - where to send your users for authentication. Probably looks like `https://login.<domain>/oauth/authorize`
+- `UAA_BASE_URL` - base URL for app where your client can exchange codes and refresh tokens for tokens. Probably looks like `https://uaa.<domain>/`.
 - `UAA_TOKEN_URL` - where your client can exchange codes and refresh tokens for tokens. Probably looks like `https://uaa.<domain>/token`
-- `UAA_CLIENT_ID` - the client id of your uaa clinet
+- `UAA_CLIENT_ID` - the client ID of your uaa clinet
 - `UAA_CLIENT_SECRET` - the client secret for your uaa client
 - `SECRET_KEY` - the key used for cookie signing
 

--- a/cf/proxy-manifest.yml
+++ b/cf/proxy-manifest.yml
@@ -20,6 +20,7 @@ applications:
 
     CF_API_URL: ((cf_url))
     UAA_AUTH_URL: ((uaa_auth_url))
+    UAA_BASE_URL: ((uaa_base_url))
     UAA_TOKEN_URL: ((uaa_token_url))
     UAA_CLIENT_ID: ((uaa_client_id))
     UAA_CLIENT_SECRET: ((uaa_client_secret))

--- a/cf/proxy-manifest.yml
+++ b/cf/proxy-manifest.yml
@@ -21,7 +21,6 @@ applications:
     CF_API_URL: ((cf_url))
     UAA_AUTH_URL: ((uaa_auth_url))
     UAA_BASE_URL: ((uaa_base_url))
-    UAA_TOKEN_URL: ((uaa_token_url))
     UAA_CLIENT_ID: ((uaa_client_id))
     UAA_CLIENT_SECRET: ((uaa_client_secret))
     SECRET_KEY: ((secret_key))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -79,7 +79,6 @@ jobs:
           cf_url: ((dev-cf-url))
           uaa_auth_url: ((dev-uaa-auth-url))
           uaa_base_url: ((dev-uaa-base-url))
-          uaa_token_url: ((dev-uaa-token-url))
           uaa_client_id: ((dev-uaa-client-id))
           uaa_client_secret: ((dev-uaa-client-secret))
           secret_key: ((dev-secret-key))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -78,6 +78,7 @@ jobs:
         vars:
           cf_url: ((dev-cf-url))
           uaa_auth_url: ((dev-uaa-auth-url))
+          uaa_base_url: ((dev-uaa-base-url))
           uaa_token_url: ((dev-uaa-token-url))
           uaa_client_id: ((dev-uaa-client-id))
           uaa_client_secret: ((dev-uaa-client-secret))

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -109,7 +109,11 @@ def create_app():
         session["orgs"] = cf.get_orgs_for_user(
             session["user_id"], session["access_token"]
         )
-        session["groups"] = uaa.get_user_groups(session["user_id"])
+
+        if session.get("client_credentials_token") is None:
+            data = uaa.get_client_credentials_token()
+            session["client_credentials_token"] = data["access_token"]
+        session["groups"] = uaa.get_user_groups(session["user_id"], session["client_credentials_token"])
 
         return redirect(session.pop("original-request", "/app/home"))
 

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -109,8 +109,7 @@ def create_app():
         )
 
         if session.get("client_credentials_token") is None:
-            data = uaa.get_client_credentials_token()
-            session["client_credentials_token"] = data["access_token"]
+            session["client_credentials_token"] = uaa.get_client_credentials_token()
 
         session["is_cf_admin"] = uaa.is_user_cf_admin(
             session["user_id"], session["client_credentials_token"]

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -95,8 +95,6 @@ def create_app():
             options=dict(verify_signature=False),
         )
 
-        print(token)
-
         session["user_id"] = token["user_id"]
         session["access_token"] = response["access_token"]
         session["refresh_token"] = response["refresh_token"]

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -170,8 +170,6 @@ def create_app():
             headers["x-proxy-user"] = session["user_id"]
             headers["x-proxy-roles"] = "admin" if session.get("is_cf_admin") else "user"
 
-        headers["x-proxy-roles"] = list_to_ext_header(session.get("groups", []))
-
         # TODO: add x-forwarded-for functionality
         headers["x-forwarded-for"] = "127.0.0.1"
 

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -113,7 +113,9 @@ def create_app():
         if session.get("client_credentials_token") is None:
             data = uaa.get_client_credentials_token()
             session["client_credentials_token"] = data["access_token"]
-        session["groups"] = uaa.get_user_groups(session["user_id"], session["client_credentials_token"])
+        session["groups"] = uaa.get_user_groups(
+            session["user_id"], session["client_credentials_token"]
+        )
 
         return redirect(session.pop("original-request", "/app/home"))
 

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -107,7 +107,7 @@ def create_app():
         session["orgs"] = cf.get_orgs_for_user(
             session["user_id"], session["access_token"]
         )
-        uaa.get_user_groups(token["user_id"], session["access_token"])
+        session["groups"] = uaa.get_user_groups(token["user_id"], session["access_token"])
 
         return redirect(session.pop("original-request", "/app/home"))
 
@@ -160,6 +160,8 @@ def create_app():
         if session.get("user_id"):
             headers["x-proxy-user"] = session["user_id"]
             headers["x-proxy-roles"] = "user"
+
+        headers["x-proxy-roles"] = list_to_ext_header(session.get("groups", []))
 
         # TODO: add x-forwarded-for functionality
         headers["x-forwarded-for"] = "127.0.0.1"

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -113,7 +113,7 @@ def create_app():
         if session.get("client_credentials_token") is None:
             data = uaa.get_client_credentials_token()
             session["client_credentials_token"] = data["access_token"]
-            
+
         session["is_cf_admin"] = uaa.is_user_cf_admin(
             session["user_id"], session["client_credentials_token"]
         )

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -113,6 +113,7 @@ def create_app():
         if session.get("client_credentials_token") is None:
             data = uaa.get_client_credentials_token()
             session["client_credentials_token"] = data["access_token"]
+            
         session["groups"] = uaa.get_user_groups(
             session["user_id"], session["client_credentials_token"]
         )

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -95,6 +95,8 @@ def create_app():
             options=dict(verify_signature=False),
         )
 
+        print(token)
+
         session["user_id"] = token["user_id"]
         session["access_token"] = response["access_token"]
         session["refresh_token"] = response["refresh_token"]
@@ -107,7 +109,7 @@ def create_app():
         session["orgs"] = cf.get_orgs_for_user(
             session["user_id"], session["access_token"]
         )
-        session["groups"] = uaa.get_user_groups(token["user_id"], session["access_token"])
+        session["groups"] = uaa.get_user_groups(session["user_id"])
 
         return redirect(session.pop("original-request", "/app/home"))
 

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -114,7 +114,7 @@ def create_app():
             data = uaa.get_client_credentials_token()
             session["client_credentials_token"] = data["access_token"]
             
-        session["groups"] = uaa.get_user_groups(
+        session["is_cf_admin"] = uaa.is_user_cf_admin(
             session["user_id"], session["client_credentials_token"]
         )
 
@@ -168,7 +168,7 @@ def create_app():
         # allowed path
         if session.get("user_id"):
             headers["x-proxy-user"] = session["user_id"]
-            headers["x-proxy-roles"] = "user"
+            headers["x-proxy-roles"] = "admin" if session.get("is_cf_admin") else "user"
 
         headers["x-proxy-roles"] = list_to_ext_header(session.get("groups", []))
 

--- a/kibana_cf_auth_proxy/app.py
+++ b/kibana_cf_auth_proxy/app.py
@@ -11,6 +11,7 @@ from kibana_cf_auth_proxy.extensions import config
 from kibana_cf_auth_proxy.proxy import proxy_request
 from kibana_cf_auth_proxy import cf
 from kibana_cf_auth_proxy.headers import list_to_ext_header
+from kibana_cf_auth_proxy import uaa
 
 
 def create_app():
@@ -106,6 +107,7 @@ def create_app():
         session["orgs"] = cf.get_orgs_for_user(
             session["user_id"], session["access_token"]
         )
+        uaa.get_user_groups(token["user_id"], session["access_token"])
 
         return redirect(session.pop("original-request", "/app/home"))
 

--- a/kibana_cf_auth_proxy/cf.py
+++ b/kibana_cf_auth_proxy/cf.py
@@ -1,14 +1,15 @@
+from urllib.parse import urljoin
 import requests
 
 from kibana_cf_auth_proxy.extensions import config
 
 
-def iterate_cf_resource(session, first_request):
+def iterate_cf_resource(session, first_response):
     """
     iterates over a v3-style, paginated resource, returning the full list of the resources
     """
     resources = []
-    data = session.get(first_request).json()
+    data = first_response.json()
     resources.extend(data["resources"])
     while data["pagination"]["next"] is not None:
         data = session.get(data["pagination"]["next"]["href"]).json()
@@ -19,8 +20,13 @@ def iterate_cf_resource(session, first_request):
 def get_spaces_for_user(user_id, token):
     with requests.Session() as s:
         s.headers["Authorization"] = f"Bearer {token}"
-        url = f"{config.CF_API_URL}v3/roles?user_guids={user_id}&types={','.join(config.PERMITTED_SPACE_ROLES)}"
-        resources = iterate_cf_resource(s, url)
+        params = {
+            "user_guids": user_id,
+            "types": ",".join(config.PERMITTED_SPACE_ROLES),
+        }
+        url = urljoin(config.CF_API_URL, "v3/roles")
+        first_response = s.get(url, params=params)
+        resources = iterate_cf_resource(s, first_response)
     spaces = [r["relationships"]["space"]["data"]["guid"] for r in resources]
     return spaces
 
@@ -28,7 +34,9 @@ def get_spaces_for_user(user_id, token):
 def get_orgs_for_user(user_id, token):
     with requests.Session() as s:
         s.headers["Authorization"] = f"Bearer {token}"
-        url = f"{config.CF_API_URL}v3/roles?user_guids={user_id}&types={','.join(config.PERMITTED_ORG_ROLES)}"
-        resources = iterate_cf_resource(s, url)
+        params = {"user_guids": user_id, "types": ",".join(config.PERMITTED_ORG_ROLES)}
+        url = urljoin(config.CF_API_URL, "v3/roles")
+        first_response = s.get(url, params=params)
+        resources = iterate_cf_resource(s, first_response)
     orgs = [r["relationships"]["organization"]["data"]["guid"] for r in resources]
     return orgs

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -15,6 +15,7 @@ class Config:
     def __init__(self):
         self.env_parser = Env()
         self.PORT = self.env_parser.int("PORT", 8080)
+        self.CF_ADMIN_GROUP_NAME = "cloud_controller.admin"
         self.PERMITTED_SPACE_ROLES = self.env_parser.list(
             "PERMITTED_SPACE_ROLES",
             ["space_developer", "space_manager", "space_auditor"],
@@ -59,6 +60,8 @@ class LocalConfig(Config):
         self.CF_API_URL = self.env_parser("CF_API_URL")
         self.UAA_AUTH_URL = self.env_parser.str("UAA_AUTH_URL")
         self.UAA_BASE_URL = self.env_parser.str("UAA_BASE_URL")
+        if self.UAA_BASE_URL[-1] != "/":
+            self.UAA_BASE_URL = f"{self.UAA_BASE_URL}/"
         self.UAA_TOKEN_URL = f"{self.UAA_BASE_URL}oauth/token"
         self.UAA_CLIENT_ID = self.env_parser.str("UAA_CLIENT_ID")
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")
@@ -80,6 +83,8 @@ class AppConfig(Config):
         self.CF_API_URL = self.env_parser("CF_API_URL")
         self.UAA_AUTH_URL = self.env_parser.str("UAA_AUTH_URL")
         self.UAA_BASE_URL = self.env_parser.str("UAA_BASE_URL")
+        if self.UAA_BASE_URL[-1] != "/":
+            self.UAA_BASE_URL = f"{self.UAA_BASE_URL}/"
         self.UAA_TOKEN_URL = f"{self.UAA_BASE_URL}oauth/token"
         self.UAA_CLIENT_ID = self.env_parser.str("UAA_CLIENT_ID")
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -59,7 +59,7 @@ class LocalConfig(Config):
         self.CF_API_URL = self.env_parser("CF_API_URL")
         self.UAA_AUTH_URL = self.env_parser.str("UAA_AUTH_URL")
         self.UAA_BASE_URL = self.env_parser.str("UAA_BASE_URL")
-        self.UAA_TOKEN_URL = self.env_parser.str("UAA_TOKEN_URL")
+        self.UAA_TOKEN_URL = f"{self.UAA_BASE_URL}oauth/token"
         self.UAA_CLIENT_ID = self.env_parser.str("UAA_CLIENT_ID")
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")
         self.SECRET_KEY = self.env_parser.str("SECRET_KEY")
@@ -80,7 +80,7 @@ class AppConfig(Config):
         self.CF_API_URL = self.env_parser("CF_API_URL")
         self.UAA_AUTH_URL = self.env_parser.str("UAA_AUTH_URL")
         self.UAA_BASE_URL = self.env_parser.str("UAA_BASE_URL")
-        self.UAA_TOKEN_URL = self.env_parser.str("UAA_TOKEN_URL")
+        self.UAA_TOKEN_URL = f"{self.UAA_BASE_URL}oauth/token"
         self.UAA_CLIENT_ID = self.env_parser.str("UAA_CLIENT_ID")
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")
         self.SECRET_KEY = self.env_parser.str("SECRET_KEY")

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -34,7 +34,7 @@ class UnitConfig(Config):
         self.SESSION_TYPE = "filesystem"
         self.CF_API_URL = "mock://cf/"
         self.UAA_AUTH_URL = "mock://uaa/authorize"
-        self.UAA_BASE_URL = "mock://uaa"
+        self.UAA_BASE_URL = "mock://uaa/"
         self.UAA_TOKEN_URL = "mock://uaa/token"
         self.UAA_CLIENT_ID = "EXAMPLE"
         self.UAA_CLIENT_SECRET = "example"

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -30,12 +30,12 @@ class UnitConfig(Config):
         super().__init__()
         self.TESTING = True
         self.DEBUG = True
-        self.KIBANA_URL = "mock://kibana/"
+        self.KIBANA_URL = "http://mock.kibana/"
         self.SESSION_TYPE = "filesystem"
-        self.CF_API_URL = "mock://cf/"
-        self.UAA_AUTH_URL = "mock://uaa/authorize"
-        self.UAA_BASE_URL = "mock://uaa/"
-        self.UAA_TOKEN_URL = "mock://uaa/token"
+        self.CF_API_URL = "http://mock.cf/"
+        self.UAA_AUTH_URL = "http://mock.uaa/authorize"
+        self.UAA_BASE_URL = "http://mock.uaa/"
+        self.UAA_TOKEN_URL = "http://mock.uaa/token"
         self.UAA_CLIENT_ID = "EXAMPLE"
         self.UAA_CLIENT_SECRET = "example"
         self.SECRET_KEY = "CHANGEME"

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -67,7 +67,7 @@ class LocalConfig(Config):
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")
         self.SECRET_KEY = self.env_parser.str("SECRET_KEY")
         self.PERMANENT_SESSION_LIFETIME = self.env_parser.int("SESSION_LIFETIME")
-        self.CF_ADMIN_GROUP_NAME = self.env_parser.int("CF_ADMIN_GROUP_NAME")
+        self.CF_ADMIN_GROUP_NAME = self.env_parser.str("CF_ADMIN_GROUP_NAME")
 
 
 class AppConfig(Config):
@@ -91,4 +91,4 @@ class AppConfig(Config):
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")
         self.SECRET_KEY = self.env_parser.str("SECRET_KEY")
         self.PERMANENT_SESSION_LIFETIME = self.env_parser.int("SESSION_LIFETIME")
-        self.CF_ADMIN_GROUP_NAME = self.env_parser.int("CF_ADMIN_GROUP_NAME")
+        self.CF_ADMIN_GROUP_NAME = self.env_parser.str("CF_ADMIN_GROUP_NAME")

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -15,7 +15,6 @@ class Config:
     def __init__(self):
         self.env_parser = Env()
         self.PORT = self.env_parser.int("PORT", 8080)
-        self.CF_ADMIN_GROUP_NAME = "cloud_controller.admin"
         self.PERMITTED_SPACE_ROLES = self.env_parser.list(
             "PERMITTED_SPACE_ROLES",
             ["space_developer", "space_manager", "space_auditor"],
@@ -42,6 +41,7 @@ class UnitConfig(Config):
         self.SECRET_KEY = "CHANGEME"
         self.PERMANENT_SESSION_LIFETIME = 120
         self.SESSION_REFRESH_EACH_REQUEST = False
+        self.CF_ADMIN_GROUP_NAME = "cloud_controller.admin"
 
 
 class LocalConfig(Config):
@@ -67,6 +67,7 @@ class LocalConfig(Config):
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")
         self.SECRET_KEY = self.env_parser.str("SECRET_KEY")
         self.PERMANENT_SESSION_LIFETIME = self.env_parser.int("SESSION_LIFETIME")
+        self.CF_ADMIN_GROUP_NAME = self.env_parser.int("CF_ADMIN_GROUP_NAME")
 
 
 class AppConfig(Config):
@@ -90,3 +91,4 @@ class AppConfig(Config):
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")
         self.SECRET_KEY = self.env_parser.str("SECRET_KEY")
         self.PERMANENT_SESSION_LIFETIME = self.env_parser.int("SESSION_LIFETIME")
+        self.CF_ADMIN_GROUP_NAME = self.env_parser.int("CF_ADMIN_GROUP_NAME")

--- a/kibana_cf_auth_proxy/config.py
+++ b/kibana_cf_auth_proxy/config.py
@@ -34,6 +34,7 @@ class UnitConfig(Config):
         self.SESSION_TYPE = "filesystem"
         self.CF_API_URL = "mock://cf/"
         self.UAA_AUTH_URL = "mock://uaa/authorize"
+        self.UAA_BASE_URL = "mock://uaa"
         self.UAA_TOKEN_URL = "mock://uaa/token"
         self.UAA_CLIENT_ID = "EXAMPLE"
         self.UAA_CLIENT_SECRET = "example"
@@ -57,6 +58,7 @@ class LocalConfig(Config):
 
         self.CF_API_URL = self.env_parser("CF_API_URL")
         self.UAA_AUTH_URL = self.env_parser.str("UAA_AUTH_URL")
+        self.UAA_BASE_URL = self.env_parser.str("UAA_BASE_URL")
         self.UAA_TOKEN_URL = self.env_parser.str("UAA_TOKEN_URL")
         self.UAA_CLIENT_ID = self.env_parser.str("UAA_CLIENT_ID")
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")
@@ -77,6 +79,7 @@ class AppConfig(Config):
 
         self.CF_API_URL = self.env_parser("CF_API_URL")
         self.UAA_AUTH_URL = self.env_parser.str("UAA_AUTH_URL")
+        self.UAA_BASE_URL = self.env_parser.str("UAA_BASE_URL")
         self.UAA_TOKEN_URL = self.env_parser.str("UAA_TOKEN_URL")
         self.UAA_CLIENT_ID = self.env_parser.str("UAA_CLIENT_ID")
         self.UAA_CLIENT_SECRET = self.env_parser.str("UAA_CLIENT_SECRET")

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -23,6 +23,7 @@ def get_user_groups(user_id, token):
     with requests.Session() as s:
         s.headers["Authorization"] = f"Bearer {token}"
         url = f"{config.UAA_BASE_URL}Users?attributes=groups&filter=id eq '{user_id}'"
+        # there should be only one resource when filtering by ID, so no need for paginating results?
         data = s.get(url).json()
         all_groups = [r["groups"] for r in data["resources"]]
         group_names = [g["display"] for user_groups in all_groups for g in user_groups]

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -1,13 +1,44 @@
 import requests
 
+from flask import session
 from kibana_cf_auth_proxy.extensions import config
 
-def get_user_groups(user_id, token):
+def client_credentials_token(s):
+    print("here")
+    response = requests.post(
+        config.UAA_TOKEN_URL,
+        data={
+            "grant_type": "client_credentials",
+            "client_id": config.UAA_CLIENT_ID,
+            "client_secret": config.UAA_CLIENT_SECRET,
+            "response_type": "token",
+        },
+        auth=requests.auth.HTTPBasicAuth(
+            config.UAA_CLIENT_ID, config.UAA_CLIENT_SECRET
+        ),
+    )
+
+    try:
+        response.raise_for_status()
+    except:
+        return "Unexpected error", 500
+
+    data = response.json()
+    return data
+    
+
+def get_user_groups(user_id):
     with requests.Session() as s:
-        s.headers["Authorization"] = f"Bearer {token}"
+        # if session.get("client_credentials_token") is None:
+        #     data = client_credentials_token(s)
+        #     session["client_credentials_token"] = data["access_token"]
+        s.headers["Authorization"] = f"Bearer {s['client_credentials_token']}"
         url = f"{config.UAA_BASE_URL}Users?attributes=groups&filter=id eq '{user_id}'"
+        print(url)
         # there should be only one resource when filtering by ID, so no need for paginating results?
         data = s.get(url).json()
+        print(data)
+        # how should error where data["resources"] doesn't exist be handled?
         all_groups = [r["groups"] for r in data["resources"]]
         group_names = [g["display"] for user_groups in all_groups for g in user_groups]
         return group_names

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -2,6 +2,7 @@ import requests
 
 from kibana_cf_auth_proxy.extensions import config
 
+
 def get_client_credentials_token():
     response = requests.post(
         config.UAA_TOKEN_URL,
@@ -23,7 +24,7 @@ def get_client_credentials_token():
 
     data = response.json()
     return data
-    
+
 
 def get_user_groups(user_id, token):
     with requests.Session() as s:

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -31,8 +31,12 @@ def is_user_cf_admin(user_id, token):
         s.headers["Authorization"] = f"Bearer {token}"
         url = f"{config.UAA_BASE_URL}Users?attributes=groups&filter=id eq '{user_id}'"
         # there should be only one resource when filtering by ID, so no need for paginating results?
-        data = s.get(url).json()
-        # how should error where data["resources"] doesn't exist be handled?
+        response = s.get(url)
+        try:
+            response.raise_for_status()
+        except:
+            return "Unexpected error", 500
+        data = response.json()
         all_groups = [r["groups"] for r in data["resources"]]
         group_names = [g["display"] for user_groups in all_groups for g in user_groups]
         return config.CF_ADMIN_GROUP_NAME in group_names

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -28,14 +28,12 @@ def get_client_credentials_token():
 def is_user_cf_admin(user_id, token):
     with requests.Session() as s:
         s.headers["Authorization"] = f"Bearer {token}"
-        url = f"{config.UAA_BASE_URL}Users?attributes=groups&filter=id eq '{user_id}'"
-        # there should be only one resource when filtering by ID, so no need for paginating results?
+        url = f"{config.UAA_BASE_URL}Users/{user_id}"
         response = s.get(url)
         try:
             response.raise_for_status()
         except:
             return "Unexpected error", 500
         data = response.json()
-        all_groups = [r["groups"] for r in data["resources"]]
-        group_names = [g["display"] for user_groups in all_groups for g in user_groups]
-        return config.CF_ADMIN_GROUP_NAME in group_names
+        user_groups = [group["display"] for group in data["groups"]]
+        return config.CF_ADMIN_GROUP_NAME in user_groups

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -3,7 +3,7 @@ import requests
 from flask import session
 from kibana_cf_auth_proxy.extensions import config
 
-def client_credentials_token(s):
+def get_client_credentials_token():
     response = requests.post(
         config.UAA_TOKEN_URL,
         data={
@@ -26,12 +26,9 @@ def client_credentials_token(s):
     return data
     
 
-def get_user_groups(user_id):
+def get_user_groups(user_id, token):
     with requests.Session() as s:
-        if session.get("client_credentials_token") is None:
-            data = client_credentials_token(s)
-            session["client_credentials_token"] = data["access_token"]
-        s.headers["Authorization"] = f"Bearer {session['client_credentials_token']}"
+        s.headers["Authorization"] = f"Bearer {token}"
         url = f"{config.UAA_BASE_URL}Users?attributes=groups&filter=id eq '{user_id}'"
         print(url)
         # there should be only one resource when filtering by ID, so no need for paginating results?

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -1,6 +1,5 @@
 import requests
 
-from flask import session
 from kibana_cf_auth_proxy.extensions import config
 
 def get_client_credentials_token():

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -1,0 +1,29 @@
+import requests
+
+from kibana_cf_auth_proxy.extensions import config
+
+
+def iterate_user_resources(session, first_url):
+    """
+    iterates over paginated resources of user info, returning the full list of the resources
+    """
+    resources = []
+    data = session.get(first_url).json()
+    resources.extend(data["resources"])
+    # this logic is wrong
+    while data["startIndex"] < data['totalResults']:
+        newStartIndex = data["startIndex"] + data["itemsPerPage"]
+        itemsPerPage = data["itemsPerPage"]
+        data = session.get(f"{first_url}&startIndex={newStartIndex}&itemsPerPage={itemsPerPage}").json()
+        resources.extend(data["resources"])
+    return resources
+
+
+def get_user_groups(user_id, token):
+    with requests.Session() as s:
+        s.headers["Authorization"] = f"Bearer {token}"
+        url = f"{config.UAA_BASE_URL}Users?attributes=groups&filter=id eq '{user_id}'"
+        data = s.get(url).json()
+        all_groups = [r["groups"] for r in data["resources"]]
+        group_names = [g["display"] for user_groups in all_groups for g in user_groups]
+        return group_names

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -2,23 +2,6 @@ import requests
 
 from kibana_cf_auth_proxy.extensions import config
 
-
-def iterate_user_resources(session, first_url):
-    """
-    iterates over paginated resources of user info, returning the full list of the resources
-    """
-    resources = []
-    data = session.get(first_url).json()
-    resources.extend(data["resources"])
-    # this logic is wrong
-    while data["startIndex"] < data['totalResults']:
-        newStartIndex = data["startIndex"] + data["itemsPerPage"]
-        itemsPerPage = data["itemsPerPage"]
-        data = session.get(f"{first_url}&startIndex={newStartIndex}&itemsPerPage={itemsPerPage}").json()
-        resources.extend(data["resources"])
-    return resources
-
-
 def get_user_groups(user_id, token):
     with requests.Session() as s:
         s.headers["Authorization"] = f"Bearer {token}"

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -22,8 +22,7 @@ def get_client_credentials_token():
     except:
         return "Unexpected error", 500
 
-    data = response.json()
-    return data
+    return response.json()["access_token"]
 
 
 def is_user_cf_admin(user_id, token):

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -26,15 +26,13 @@ def get_client_credentials_token():
     return data
 
 
-def get_user_groups(user_id, token):
+def is_user_cf_admin(user_id, token):
     with requests.Session() as s:
         s.headers["Authorization"] = f"Bearer {token}"
         url = f"{config.UAA_BASE_URL}Users?attributes=groups&filter=id eq '{user_id}'"
-        print(url)
         # there should be only one resource when filtering by ID, so no need for paginating results?
         data = s.get(url).json()
-        print(data)
         # how should error where data["resources"] doesn't exist be handled?
         all_groups = [r["groups"] for r in data["resources"]]
         group_names = [g["display"] for user_groups in all_groups for g in user_groups]
-        return group_names
+        return config.CF_ADMIN_GROUP_NAME in group_names

--- a/kibana_cf_auth_proxy/uaa.py
+++ b/kibana_cf_auth_proxy/uaa.py
@@ -4,7 +4,6 @@ from flask import session
 from kibana_cf_auth_proxy.extensions import config
 
 def client_credentials_token(s):
-    print("here")
     response = requests.post(
         config.UAA_TOKEN_URL,
         data={
@@ -29,10 +28,10 @@ def client_credentials_token(s):
 
 def get_user_groups(user_id):
     with requests.Session() as s:
-        # if session.get("client_credentials_token") is None:
-        #     data = client_credentials_token(s)
-        #     session["client_credentials_token"] = data["access_token"]
-        s.headers["Authorization"] = f"Bearer {s['client_credentials_token']}"
+        if session.get("client_credentials_token") is None:
+            data = client_credentials_token(s)
+            session["client_credentials_token"] = data["access_token"]
+        s.headers["Authorization"] = f"Bearer {session['client_credentials_token']}"
         url = f"{config.UAA_BASE_URL}Users?attributes=groups&filter=id eq '{user_id}'"
         print(url)
         # there should be only one resource when filtering by ID, so no need for paginating results?

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,7 @@ def uaa_user_is_admin_response():
       ]
    }"""
 
+
 @pytest.fixture()
 def uaa_user_is_not_admin_response():
     return """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import jwt
 import pytest
 
 from kibana_cf_auth_proxy.app import create_app
@@ -36,6 +37,12 @@ def client():
     with app.test_client() as client:
         yield client
 
+@pytest.fixture(scope="function")
+def fake_jwt_token(claims=None):
+    # todo, clean this up
+    claims = claims or {"user_id": "test_user"}
+    token = jwt.encode(claims, "", "HS256")
+    return token
 
 @pytest.fixture(scope="function")
 def authenticated_client(client):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 
 from kibana_cf_auth_proxy.app import create_app
 
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "focus: Only run this test.")
 
@@ -37,12 +38,14 @@ def client():
     with app.test_client() as client:
         yield client
 
+
 @pytest.fixture(scope="function")
 def fake_jwt_token(claims=None):
     # todo, clean this up
     claims = claims or {"user_id": "test_user"}
     token = jwt.encode(claims, "", "HS256")
     return token
+
 
 @pytest.fixture(scope="function")
 def authenticated_client(client):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,3 +148,27 @@ def simple_org_response():
         }
       ]
     } """
+
+
+@pytest.fixture()
+def simple_users_response():
+    return """
+   {
+      "resources": [
+         {
+            "groups": [
+               {
+                  "value": "1234-abcd-5678-efgh-9z9d",
+                  "display": "cloud_controller.admin",
+                  "type": "DIRECT"
+               }
+            ]
+         }
+      ],
+      "startIndex": 1,
+      "itemsPerPage": 100,
+      "totalResults": 1,
+      "schemas": [
+         "urn:scim:schemas:core:1.0"
+      ]
+   }"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,7 +151,7 @@ def simple_org_response():
 
 
 @pytest.fixture()
-def simple_users_response():
+def uaa_user_groups_response():
     return """
    {
       "resources": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,11 @@ def uaa_user_groups_response():
                   "value": "1234-abcd-5678-efgh-9z9d",
                   "display": "cloud_controller.admin",
                   "type": "DIRECT"
+               },
+               {
+                  "value": "1234-abcd-5678-efgh-9z9d",
+                  "display": "network.admin",
+                  "type": "DIRECT"
                }
             ]
          }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import jwt
 import pytest
 
 from kibana_cf_auth_proxy.app import create_app
@@ -40,13 +39,6 @@ def client():
 
 
 @pytest.fixture(scope="function")
-def fake_jwt_token(claims=None):
-    # todo, clean this up
-    claims = claims or {"user_id": "test_user"}
-    token = jwt.encode(claims, "", "HS256")
-    return token
-
-
 @pytest.fixture(scope="function")
 def authenticated_client(client):
     with client.session_transaction() as s:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,10 +53,10 @@ def simple_space_response():
       "total_results": 1,
       "total_pages": 1,
       "first": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
       },
       "next": null,
       "previous": null
@@ -84,13 +84,13 @@ def simple_space_response():
          },
          "links": {
             "self": {
-               "href": "mock://cf/v3/roles/role-guid-1"
+               "href": "http://mock.cf/v3/roles/role-guid-1"
             },
             "user": {
-               "href": "mock://cf/v3/users/a-user-guid"
+               "href": "http://mock.cf/v3/users/a-user-guid"
             },
             "space": {
-               "href": "mock://cf/v3/spaces/space-guid-1"
+               "href": "http://mock.cf/v3/spaces/space-guid-1"
             }
          }
         }
@@ -106,10 +106,10 @@ def simple_org_response():
       "total_results": 1,
       "total_pages": 1,
       "first": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=org_manager&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=org_manager&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=org_manager&user_guids=a-user-guid"
       },
       "next": null,
       "previous": null
@@ -137,13 +137,13 @@ def simple_org_response():
          },
          "links": {
             "self": {
-               "href": "mock://cf/v3/roles/role-guid-1"
+               "href": "http://mock.cf/v3/roles/role-guid-1"
             },
             "user": {
-               "href": "mock://cf/v3/users/a-user-guid"
+               "href": "http://mock.cf/v3/users/a-user-guid"
             },
             "organization": {
-               "href": "mock://cf/v3/spaces/org-guid-1"
+               "href": "http://mock.cf/v3/spaces/org-guid-1"
             }
          }
         }
@@ -155,22 +155,12 @@ def simple_org_response():
 def uaa_user_is_admin_response():
     return """
    {
-      "resources": [
+      "groups": [
          {
-            "groups": [
-               {
-                  "value": "1234-abcd-5678-efgh-9z9d",
-                  "display": "cloud_controller.admin",
-                  "type": "DIRECT"
-               }
-            ]
+            "value": "1234-abcd-5678-efgh-9z9d",
+            "display": "cloud_controller.admin",
+            "type": "DIRECT"
          }
-      ],
-      "startIndex": 1,
-      "itemsPerPage": 100,
-      "totalResults": 1,
-      "schemas": [
-         "urn:scim:schemas:core:1.0"
       ]
    }"""
 
@@ -179,21 +169,11 @@ def uaa_user_is_admin_response():
 def uaa_user_is_not_admin_response():
     return """
    {
-      "resources": [
+      "groups": [
          {
-            "groups": [
-               {
-                  "value": "1234-abcd-5678-efgh-9z9d",
-                  "display": "not.admin",
-                  "type": "DIRECT"
-               }
-            ]
+            "value": "1234-abcd-5678-efgh-9z9d",
+            "display": "not.admin",
+            "type": "DIRECT"
          }
-      ],
-      "startIndex": 1,
-      "itemsPerPage": 100,
-      "totalResults": 1,
-      "schemas": [
-         "urn:scim:schemas:core:1.0"
       ]
    }"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ def client():
 
 
 @pytest.fixture(scope="function")
-@pytest.fixture(scope="function")
 def authenticated_client(client):
     with client.session_transaction() as s:
         s["user_id"] = "me"
@@ -153,7 +152,7 @@ def simple_org_response():
 
 
 @pytest.fixture()
-def uaa_user_groups_response():
+def uaa_user_is_admin_response():
     return """
    {
       "resources": [
@@ -163,10 +162,28 @@ def uaa_user_groups_response():
                   "value": "1234-abcd-5678-efgh-9z9d",
                   "display": "cloud_controller.admin",
                   "type": "DIRECT"
-               },
+               }
+            ]
+         }
+      ],
+      "startIndex": 1,
+      "itemsPerPage": 100,
+      "totalResults": 1,
+      "schemas": [
+         "urn:scim:schemas:core:1.0"
+      ]
+   }"""
+
+@pytest.fixture()
+def uaa_user_is_not_admin_response():
+    return """
+   {
+      "resources": [
+         {
+            "groups": [
                {
                   "value": "1234-abcd-5678-efgh-9z9d",
-                  "display": "network.admin",
+                  "display": "not.admin",
                   "type": "DIRECT"
                }
             ]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -53,6 +53,7 @@ def test_app_filters_headers(authenticated_client):
             if header.lower() == "x-proxy-ext-orgids":
                 assert m.request_history[0]._request.headers[header] != "4,5,6"
 
+
 def test_orgs_set_correctly(client):
     with requests_mock.Mocker() as m:
         m.get(
@@ -75,6 +76,7 @@ def test_spaces_set_correctly(client):
             s["user_id"] = "me"
             s["spaces"] = ["space-id-1", "space-id-2"]
         client.get("/home")
+
 
 def test_roles_set_correctly(client):
     with requests_mock.Mocker() as m:

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -77,8 +77,17 @@ def test_spaces_set_correctly(client):
             s["spaces"] = ["space-id-1", "space-id-2"]
         client.get("/home")
 
+def test_user_role_set_correctly(client):
+    with requests_mock.Mocker() as m:
+        m.get(
+            "mock://kibana/home",
+            request_headers={"x-proxy-roles": r'"user"'},
+        )
+        with client.session_transaction() as s:
+            s["user_id"] = "me"
+        client.get("/home")
 
-def test_roles_set_correctly(client):
+def test_admin_role_set_correctly(client):
     with requests_mock.Mocker() as m:
         m.get(
             "mock://kibana/home",
@@ -87,4 +96,5 @@ def test_roles_set_correctly(client):
         with client.session_transaction() as s:
             s["user_id"] = "me"
             s["groups"] = ["admin"]
+            s["is_cf_admin"] = True
         client.get("/home")

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -81,20 +81,20 @@ def test_user_role_set_correctly(client):
     with requests_mock.Mocker() as m:
         m.get(
             "mock://kibana/home",
-            request_headers={"x-proxy-roles": r'"user"'},
         )
         with client.session_transaction() as s:
             s["user_id"] = "me"
         client.get("/home")
+        assert m.last_request._request.headers['x-proxy-roles'] is 'user'
 
 def test_admin_role_set_correctly(client):
     with requests_mock.Mocker() as m:
         m.get(
-            "mock://kibana/home",
-            request_headers={"x-proxy-roles": r'"admin"'},
+            "mock://kibana/home"
         )
         with client.session_transaction() as s:
             s["user_id"] = "me"
             s["groups"] = ["admin"]
             s["is_cf_admin"] = True
         client.get("/home")
+        assert m.last_request._request.headers['x-proxy-roles'] is 'admin'

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -14,7 +14,8 @@ def test_redirected_to_auth(client):
     query_params = parse.parse_qs(location.query)
     assert response.status_code == 302
     assert query_params["state"] is not None
-    assert location.scheme == "mock"
+    assert location.scheme == "http"
+    assert location.hostname == "mock.uaa"
     assert query_params["redirect_uri"][0][0:4] == "http"
     assert query_params["scope"][0] == "openid cloud_controller.read scim.read"
     assert query_params["response_type"][0] == "code"

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -84,5 +84,5 @@ def test_roles_set_correctly(client):
         )
         with client.session_transaction() as s:
             s["user_id"] = "me"
-            s["roles"] = ["admin"]
+            s["groups"] = ["admin"]
         client.get("/home")

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -22,7 +22,7 @@ def test_redirected_to_auth(client):
 
 def test_app_proxies_arbitrary_paths(authenticated_client):
     with requests_mock.Mocker() as m:
-        m.get("mock://kibana/foo/bar/baz/quux/")
+        m.get("http://mock.kibana/foo/bar/baz/quux/")
         authenticated_client.get("/foo/bar/baz/quux/")
     assert m.called
 
@@ -33,7 +33,7 @@ def test_app_filters_headers(authenticated_client):
     it should be dropped or changed
     """
     with requests_mock.Mocker() as m:
-        m.get("mock://kibana/foo/bar/baz/quux/")
+        m.get("http://mock.kibana/foo/bar/baz/quux/")
         authenticated_client.get(
             "/foo/bar/baz/quux/",
             headers={
@@ -57,7 +57,7 @@ def test_app_filters_headers(authenticated_client):
 def test_orgs_set_correctly(client):
     with requests_mock.Mocker() as m:
         m.get(
-            "mock://kibana/home",
+            "http://mock.kibana/home",
             request_headers={"x-proxy-ext-orgids": r'"org-id-1", "org-id-2"'},
         )
         with client.session_transaction() as s:
@@ -69,7 +69,7 @@ def test_orgs_set_correctly(client):
 def test_spaces_set_correctly(client):
     with requests_mock.Mocker() as m:
         m.get(
-            "mock://kibana/home",
+            "http://mock.kibana/home",
             request_headers={"x-proxy-ext-spaceids": r'"space-id-1", "space-id-2"'},
         )
         with client.session_transaction() as s:
@@ -81,7 +81,7 @@ def test_spaces_set_correctly(client):
 def test_user_role_set_correctly(client):
     with requests_mock.Mocker() as m:
         m.get(
-            "mock://kibana/home",
+            "http://mock.kibana/home",
         )
         with client.session_transaction() as s:
             s["user_id"] = "me"
@@ -91,7 +91,7 @@ def test_user_role_set_correctly(client):
 
 def test_admin_role_set_correctly(client):
     with requests_mock.Mocker() as m:
-        m.get("mock://kibana/home")
+        m.get("http://mock.kibana/home")
         with client.session_transaction() as s:
             s["user_id"] = "me"
             s["groups"] = ["admin"]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -77,6 +77,7 @@ def test_spaces_set_correctly(client):
             s["spaces"] = ["space-id-1", "space-id-2"]
         client.get("/home")
 
+
 def test_user_role_set_correctly(client):
     with requests_mock.Mocker() as m:
         m.get(
@@ -85,16 +86,15 @@ def test_user_role_set_correctly(client):
         with client.session_transaction() as s:
             s["user_id"] = "me"
         client.get("/home")
-        assert m.last_request._request.headers['x-proxy-roles'] == 'user'
+        assert m.last_request._request.headers["x-proxy-roles"] == "user"
+
 
 def test_admin_role_set_correctly(client):
     with requests_mock.Mocker() as m:
-        m.get(
-            "mock://kibana/home"
-        )
+        m.get("mock://kibana/home")
         with client.session_transaction() as s:
             s["user_id"] = "me"
             s["groups"] = ["admin"]
             s["is_cf_admin"] = True
         client.get("/home")
-        assert m.last_request._request.headers['x-proxy-roles'] == 'admin'
+        assert m.last_request._request.headers["x-proxy-roles"] == "admin"

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -75,3 +75,14 @@ def test_spaces_set_correctly(client):
             s["user_id"] = "me"
             s["spaces"] = ["space-id-1", "space-id-2"]
         client.get("/home")
+
+def test_roles_set_correctly(client):
+    with requests_mock.Mocker() as m:
+        m.get(
+            "mock://kibana/home",
+            request_headers={"x-proxy-roles": r'"admin"'},
+        )
+        with client.session_transaction() as s:
+            s["user_id"] = "me"
+            s["roles"] = ["admin"]
+        client.get("/home")

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -85,7 +85,7 @@ def test_user_role_set_correctly(client):
         with client.session_transaction() as s:
             s["user_id"] = "me"
         client.get("/home")
-        assert m.last_request._request.headers['x-proxy-roles'] is 'user'
+        assert m.last_request._request.headers['x-proxy-roles'] == 'user'
 
 def test_admin_role_set_correctly(client):
     with requests_mock.Mocker() as m:
@@ -97,4 +97,4 @@ def test_admin_role_set_correctly(client):
             s["groups"] = ["admin"]
             s["is_cf_admin"] = True
         client.get("/home")
-        assert m.last_request._request.headers['x-proxy-roles'] is 'admin'
+        assert m.last_request._request.headers['x-proxy-roles'] == 'admin'

--- a/tests/unit/test_authn.py
+++ b/tests/unit/test_authn.py
@@ -10,11 +10,14 @@ import string
 
 from kibana_cf_auth_proxy.extensions import config
 
+
 def make_random_token():
     return "".join(random.choice(string.ascii_letters) for i in range(10))
 
+
 def is_auth_code_token_request(request):
-    return 'grant_type=authorization_code' in request.text
+    return "grant_type=authorization_code" in request.text
+
 
 def is_valid_auth_code_token_request(request):
     data = request.text
@@ -23,10 +26,18 @@ def is_valid_auth_code_token_request(request):
     assert data["code"][0] == "1234"
     assert data["redirect_uri"][0] == "http://localhost/cb"
 
-def is_client_credentials_token_request(request):
-    return 'grant_type=client_credentials' in request.text
 
-def test_callback_happy_path(client, fake_jwt_token, simple_org_response, simple_space_response, uaa_user_groups_response):
+def is_client_credentials_token_request(request):
+    return "grant_type=client_credentials" in request.text
+
+
+def test_callback_happy_path(
+    client,
+    fake_jwt_token,
+    simple_org_response,
+    simple_space_response,
+    uaa_user_groups_response,
+):
     # go to a page to get redirected to log in
     response = client.get("/foo")
     location_str = f"{response.headers['location']}"
@@ -86,8 +97,10 @@ def test_callback_happy_path(client, fake_jwt_token, simple_org_response, simple
         assert s.get("spaces") == ["space-guid-1"]
         assert s.get("orgs") == ["org-guid-1"]
         assert s.get("client_credentials_token") is not None
-        assert sorted(s.get("groups")) == sorted(["cloud_controller.admin", "network.admin"])
-    
+        assert sorted(s.get("groups")) == sorted(
+            ["cloud_controller.admin", "network.admin"]
+        )
+
     is_valid_auth_code_token_request(m.request_history[0])
 
     client_creds_token_request = m.request_history[3]

--- a/tests/unit/test_authn.py
+++ b/tests/unit/test_authn.py
@@ -84,11 +84,11 @@ def test_callback_happy_path(
             text=uaa_user_is_admin_response,
         )
         m.get(
-            "http://cf.mock/v3/roles?user_guids=test_user&types=space_developer,space_manager,space_auditor",
+            "http://mock.cf/v3/roles?user_guids=test_user&types=space_developer,space_manager,space_auditor",
             text=simple_space_response,
         )
         m.get(
-            "http://cf.mock/v3/roles?user_guids=test_user&types=organization_manager,organization_auditor",
+            "http://mock.cf/v3/roles?user_guids=test_user&types=organization_manager,organization_auditor",
             text=simple_org_response,
         )
         resp = client.get(f"/cb?code=1234&state={csrf}")

--- a/tests/unit/test_authn.py
+++ b/tests/unit/test_authn.py
@@ -63,7 +63,7 @@ def test_callback_happy_path(
             "jti": "idk",
         }
         m.post(
-            "http://uaa.mock/token",
+            "http://mock.uaa/token",
             additional_matcher=is_auth_code_token_request,
             text=json.dumps(body),
         )
@@ -75,12 +75,12 @@ def test_callback_happy_path(
             "jti": "idk",
         }
         m.post(
-            "http://uaa.mock/token",
+            "http://mock.uaa/token",
             additional_matcher=is_client_credentials_token_request,
             text=json.dumps(client_creds_response),
         )
         m.get(
-            "http://uaa.mock/Users?attributes=groups&filter=id eq 'test_user'",
+            "http://mock.uaa/Users/test_user",
             text=uaa_user_is_admin_response,
         )
         m.get(
@@ -134,7 +134,7 @@ def test_callback_bad_csrf(client):
             "jti": "idk",
         }
         m.post(
-            "http://uaa.mock/token",
+            "http://mock.uaa/token",
             additional_matcher=is_auth_code_token_request,
             text=json.dumps(body),
         )
@@ -161,7 +161,7 @@ def test_callback_no_csrf(client):
             "jti": "idk",
         }
         m.post(
-            "http://uaa.mock/token",
+            "http://mock.uaa/token",
             additional_matcher=is_auth_code_token_request,
             text=json.dumps(body),
         )
@@ -207,7 +207,7 @@ def test_uaa_token_refreshed(client):
             "expires_in": 2000,
         }
         m.post(
-            "http://uaa.mock/token",
+            "http://mock.uaa/token",
             additional_matcher=validate_request,
             text=json.dumps(body),
         )

--- a/tests/unit/test_authn.py
+++ b/tests/unit/test_authn.py
@@ -63,7 +63,7 @@ def test_callback_happy_path(
             "jti": "idk",
         }
         m.post(
-            "mock://uaa/token",
+            "http://uaa.mock/token",
             additional_matcher=is_auth_code_token_request,
             text=json.dumps(body),
         )
@@ -75,20 +75,20 @@ def test_callback_happy_path(
             "jti": "idk",
         }
         m.post(
-            "mock://uaa/token",
+            "http://uaa.mock/token",
             additional_matcher=is_client_credentials_token_request,
             text=json.dumps(client_creds_response),
         )
         m.get(
-            "mock://uaa/Users?attributes=groups&filter=id eq 'test_user'",
+            "http://uaa.mock/Users?attributes=groups&filter=id eq 'test_user'",
             text=uaa_user_is_admin_response,
         )
         m.get(
-            "mock://cf/v3/roles?user_guids=test_user&types=space_developer,space_manager,space_auditor",
+            "http://cf.mock/v3/roles?user_guids=test_user&types=space_developer,space_manager,space_auditor",
             text=simple_space_response,
         )
         m.get(
-            "mock://cf/v3/roles?user_guids=test_user&types=organization_manager,organization_auditor",
+            "http://cf.mock/v3/roles?user_guids=test_user&types=organization_manager,organization_auditor",
             text=simple_org_response,
         )
         resp = client.get(f"/cb?code=1234&state={csrf}")
@@ -134,7 +134,7 @@ def test_callback_bad_csrf(client):
             "jti": "idk",
         }
         m.post(
-            "mock://uaa/token",
+            "http://uaa.mock/token",
             additional_matcher=is_auth_code_token_request,
             text=json.dumps(body),
         )
@@ -161,7 +161,7 @@ def test_callback_no_csrf(client):
             "jti": "idk",
         }
         m.post(
-            "mock://uaa/token",
+            "http://uaa.mock/token",
             additional_matcher=is_auth_code_token_request,
             text=json.dumps(body),
         )
@@ -207,7 +207,7 @@ def test_uaa_token_refreshed(client):
             "expires_in": 2000,
         }
         m.post(
-            "mock://uaa/token",
+            "http://uaa.mock/token",
             additional_matcher=validate_request,
             text=json.dumps(body),
         )

--- a/tests/unit/test_authn.py
+++ b/tests/unit/test_authn.py
@@ -44,7 +44,7 @@ def test_callback_happy_path(
     client,
     simple_org_response,
     simple_space_response,
-    uaa_user_groups_response,
+    uaa_user_is_admin_response,
 ):
     # go to a page to get redirected to log in
     response = client.get("/foo")
@@ -81,7 +81,7 @@ def test_callback_happy_path(
         )
         m.get(
             "mock://uaa/Users?attributes=groups&filter=id eq 'test_user'",
-            text=uaa_user_groups_response,
+            text=uaa_user_is_admin_response,
         )
         m.get(
             "mock://cf/v3/roles?user_guids=test_user&types=space_developer,space_manager,space_auditor",
@@ -105,9 +105,7 @@ def test_callback_happy_path(
         assert s.get("spaces") == ["space-guid-1"]
         assert s.get("orgs") == ["org-guid-1"]
         assert s.get("client_credentials_token") is not None
-        assert sorted(s.get("groups")) == sorted(
-            ["cloud_controller.admin", "network.admin"]
-        )
+        assert s.get("is_cf_admin") is True
 
     is_valid_auth_code_token_request(m.request_history[0])
 

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -12,13 +12,13 @@ def test_gets_spaces():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
       },
       "last": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "next": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "previous": null
    },
@@ -45,13 +45,13 @@ def test_gets_spaces():
          },
          "links": {
             "self": {
-               "href": "http://cf.mock/v3/roles/role-guid-1"
+               "href": "http://mock.cf/v3/roles/role-guid-1"
             },
             "user": {
-               "href": "http://cf.mock/v3/users/a-user-guid"
+               "href": "http://mock.cf/v3/users/a-user-guid"
             },
             "space": {
-               "href": "http://cf.mock/v3/spaces/space-guid-1"
+               "href": "http://mock.cf/v3/spaces/space-guid-1"
             }
          }
         }
@@ -63,14 +63,14 @@ def test_gets_spaces():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "last": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "next": null,
       "previous": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       }
    },
    "resources": [
@@ -96,13 +96,13 @@ def test_gets_spaces():
          },
          "links": {
             "self": {
-               "href": "http://cf.mock/v3/roles/role-guid-2"
+               "href": "http://mock.cf/v3/roles/role-guid-2"
             },
             "user": {
-               "href": "http://cf.mock/v3/users/a-user-guid"
+               "href": "http://mock.cf/v3/users/a-user-guid"
             },
             "space": {
-               "href": "http://cf.mock/v3/spaces/space-guid-2"
+               "href": "http://mock.cf/v3/spaces/space-guid-2"
             }
          }
         }
@@ -110,11 +110,11 @@ def test_gets_spaces():
     }
     """
         m.get(
-            "http://cf.mock/v3/roles?user_guids=a-user-id&types=space_developer,space_manager,space_auditor",
+            "http://mock.cf/v3/roles?user_guids=a-user-id&types=space_developer,space_manager,space_auditor",
             text=response_1,
         )
         m.get(
-            "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid",
+            "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid",
             text=response_2,
         )
         assert sorted(cf.get_spaces_for_user("a-user-id", "a_token")) == sorted(
@@ -130,13 +130,13 @@ def test_gets_roles():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
       },
       "last": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
       },
       "next": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
       },
       "previous": null
    },
@@ -163,13 +163,13 @@ def test_gets_roles():
          },
          "links": {
             "self": {
-               "href": "http://cf.mock/v3/roles/role-guid-1"
+               "href": "http://mock.cf/v3/roles/role-guid-1"
             },
             "user": {
-               "href": "http://cf.mock/v3/users/a-user-guid"
+               "href": "http://mock.cf/v3/users/a-user-guid"
             },
             "organization": {
-               "href": "http://cf.mock/v3/organization/org-guid-1"
+               "href": "http://mock.cf/v3/organization/org-guid-1"
             }
          }
         }
@@ -181,14 +181,14 @@ def test_gets_roles():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
       },
       "last": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
       },
       "next": null,
       "previous": {
-         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
       }
    },
    "resources": [
@@ -214,13 +214,13 @@ def test_gets_roles():
          },
          "links": {
             "self": {
-               "href": "http://cf.mock/v3/roles/role-guid-2"
+               "href": "http://mock.cf/v3/roles/role-guid-2"
             },
             "user": {
-               "href": "http://cf.mock/v3/users/a-user-guid"
+               "href": "http://mock.cf/v3/users/a-user-guid"
             },
             "organization": {
-               "href": "http://cf.mock/v3/organizations/org-guid-2"
+               "href": "http://mock.cf/v3/organizations/org-guid-2"
             }
          }
         }
@@ -228,11 +228,11 @@ def test_gets_roles():
     }
     """
         m.get(
-            "http://cf.mock/v3/roles?user_guids=a-user-id&types=organization_manager,organization_auditor",
+            "http://mock.cf/v3/roles?user_guids=a-user-id&types=organization_manager,organization_auditor",
             text=response_1,
         )
         m.get(
-            "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid",
+            "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid",
             text=response_2,
         )
         assert sorted(cf.get_orgs_for_user("a-user-id", "a_token")) == sorted(

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -12,13 +12,13 @@ def test_gets_spaces():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "next": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "previous": null
    },
@@ -45,13 +45,13 @@ def test_gets_spaces():
          },
          "links": {
             "self": {
-               "href": "mock://cf/v3/roles/role-guid-1"
+               "href": "http://cf.mock/v3/roles/role-guid-1"
             },
             "user": {
-               "href": "mock://cf/v3/users/a-user-guid"
+               "href": "http://cf.mock/v3/users/a-user-guid"
             },
             "space": {
-               "href": "mock://cf/v3/spaces/space-guid-1"
+               "href": "http://cf.mock/v3/spaces/space-guid-1"
             }
          }
         }
@@ -63,14 +63,14 @@ def test_gets_spaces():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       },
       "next": null,
       "previous": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
       }
    },
    "resources": [
@@ -96,13 +96,13 @@ def test_gets_spaces():
          },
          "links": {
             "self": {
-               "href": "mock://cf/v3/roles/role-guid-2"
+               "href": "http://cf.mock/v3/roles/role-guid-2"
             },
             "user": {
-               "href": "mock://cf/v3/users/a-user-guid"
+               "href": "http://cf.mock/v3/users/a-user-guid"
             },
             "space": {
-               "href": "mock://cf/v3/spaces/space-guid-2"
+               "href": "http://cf.mock/v3/spaces/space-guid-2"
             }
          }
         }
@@ -110,11 +110,11 @@ def test_gets_spaces():
     }
     """
         m.get(
-            "mock://cf/v3/roles?user_guids=a-user-id&types=space_developer,space_manager,space_auditor",
+            "http://cf.mock/v3/roles?user_guids=a-user-id&types=space_developer,space_manager,space_auditor",
             text=response_1,
         )
         m.get(
-            "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid",
+            "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid",
             text=response_2,
         )
         assert sorted(cf.get_spaces_for_user("a-user-id", "a_token")) == sorted(
@@ -130,13 +130,13 @@ def test_gets_roles():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
       },
       "next": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
       },
       "previous": null
    },
@@ -163,13 +163,13 @@ def test_gets_roles():
          },
          "links": {
             "self": {
-               "href": "mock://cf/v3/roles/role-guid-1"
+               "href": "http://cf.mock/v3/roles/role-guid-1"
             },
             "user": {
-               "href": "mock://cf/v3/users/a-user-guid"
+               "href": "http://cf.mock/v3/users/a-user-guid"
             },
             "organization": {
-               "href": "mock://cf/v3/organization/org-guid-1"
+               "href": "http://cf.mock/v3/organization/org-guid-1"
             }
          }
         }
@@ -181,14 +181,14 @@ def test_gets_roles():
       "total_results": 2,
       "total_pages": 2,
       "first": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
       },
       "last": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
       },
       "next": null,
       "previous": {
-         "href": "mock://cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
+         "href": "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid"
       }
    },
    "resources": [
@@ -214,13 +214,13 @@ def test_gets_roles():
          },
          "links": {
             "self": {
-               "href": "mock://cf/v3/roles/role-guid-2"
+               "href": "http://cf.mock/v3/roles/role-guid-2"
             },
             "user": {
-               "href": "mock://cf/v3/users/a-user-guid"
+               "href": "http://cf.mock/v3/users/a-user-guid"
             },
             "organization": {
-               "href": "mock://cf/v3/organizations/org-guid-2"
+               "href": "http://cf.mock/v3/organizations/org-guid-2"
             }
          }
         }
@@ -228,11 +228,11 @@ def test_gets_roles():
     }
     """
         m.get(
-            "mock://cf/v3/roles?user_guids=a-user-id&types=organization_manager,organization_auditor",
+            "http://cf.mock/v3/roles?user_guids=a-user-id&types=organization_manager,organization_auditor",
             text=response_1,
         )
         m.get(
-            "mock://cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid",
+            "http://cf.mock/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=organization_manager,organization_auditor&user_guids=a-user-guid",
             text=response_2,
         )
         assert sorted(cf.get_orgs_for_user("a-user-id", "a_token")) == sorted(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -24,6 +24,7 @@ def test_config_loads(monkeypatch):
         "organization_manager",
         "organization_auditor",
     ]
+    assert config.CF_ADMIN_GROUP_NAME == "cloud_controller.admin"
 
 
 @pytest.mark.parametrize(
@@ -40,6 +41,7 @@ def test_local_config(monkeypatch, kibana_url):
     monkeypatch.setenv("UAA_CLIENT_SECRET", "CHANGEME")
     monkeypatch.setenv("SECRET_KEY", "changeme")
     monkeypatch.setenv("SESSION_LIFETIME", "3600")
+    monkeypatch.setenv("CF_ADMIN_GROUP_NAME", "random-group")
     config = config_from_env()
     assert config.PORT == 8888
     assert config.KIBANA_URL == "https://kibana.example.com/"
@@ -53,6 +55,7 @@ def test_local_config(monkeypatch, kibana_url):
     assert config.CF_API_URL == "https://api.example.com/"
     assert config.SECRET_KEY == "changeme"
     assert config.PERMANENT_SESSION_LIFETIME == 3600
+    assert config.CF_ADMIN_GROUP_NAME == "random-group"
 
 
 @pytest.mark.parametrize(
@@ -69,6 +72,7 @@ def test_prod_config(monkeypatch, kibana_url):
     monkeypatch.setenv("UAA_CLIENT_SECRET", "CHANGEME")
     monkeypatch.setenv("SECRET_KEY", "changeme")
     monkeypatch.setenv("SESSION_LIFETIME", "3600")
+    monkeypatch.setenv("CF_ADMIN_GROUP_NAME", "random-group")
     config = config_from_env()
     assert config.PORT == 8888
     assert config.KIBANA_URL == "https://kibana.example.com/"
@@ -91,3 +95,4 @@ def test_prod_config(monkeypatch, kibana_url):
         "organization_manager",
         "organization_auditor",
     ]
+    assert config.CF_ADMIN_GROUP_NAME == "random-group"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -36,7 +36,6 @@ def test_local_config(monkeypatch, kibana_url):
     monkeypatch.setenv("CF_API_URL", "https://api.example.com/")
     monkeypatch.setenv("UAA_AUTH_URL", "https://uaa.example.com/authorize")
     monkeypatch.setenv("UAA_BASE_URL", "https://uaa.example.com/")
-    monkeypatch.setenv("UAA_TOKEN_URL", "https://uaa.example.com/token")
     monkeypatch.setenv("UAA_CLIENT_ID", "feedabee")
     monkeypatch.setenv("UAA_CLIENT_SECRET", "CHANGEME")
     monkeypatch.setenv("SECRET_KEY", "changeme")
@@ -48,7 +47,7 @@ def test_local_config(monkeypatch, kibana_url):
     assert config.TESTING
     assert config.UAA_AUTH_URL == "https://uaa.example.com/authorize"
     assert config.UAA_BASE_URL == "https://uaa.example.com/"
-    assert config.UAA_TOKEN_URL == "https://uaa.example.com/token"
+    assert config.UAA_TOKEN_URL == "https://uaa.example.com/oauth/token"
     assert config.UAA_CLIENT_ID == "feedabee"
     assert config.UAA_CLIENT_SECRET == "CHANGEME"
     assert config.CF_API_URL == "https://api.example.com/"
@@ -65,7 +64,6 @@ def test_prod_config(monkeypatch, kibana_url):
     monkeypatch.setenv("KIBANA_URL", kibana_url)
     monkeypatch.setenv("UAA_AUTH_URL", "https://uaa.example.com/authorize")
     monkeypatch.setenv("UAA_BASE_URL", "https://uaa.example.com/")
-    monkeypatch.setenv("UAA_TOKEN_URL", "https://uaa.example.com/token")
     monkeypatch.setenv("CF_API_URL", "https://api.example.com/")
     monkeypatch.setenv("UAA_CLIENT_ID", "feedabee")
     monkeypatch.setenv("UAA_CLIENT_SECRET", "CHANGEME")
@@ -78,7 +76,7 @@ def test_prod_config(monkeypatch, kibana_url):
     assert not config.TESTING
     assert config.UAA_AUTH_URL == "https://uaa.example.com/authorize"
     assert config.UAA_BASE_URL == "https://uaa.example.com/"
-    assert config.UAA_TOKEN_URL == "https://uaa.example.com/token"
+    assert config.UAA_TOKEN_URL == "https://uaa.example.com/oauth/token"
     assert config.UAA_CLIENT_ID == "feedabee"
     assert config.UAA_CLIENT_SECRET == "CHANGEME"
     assert config.CF_API_URL == "https://api.example.com/"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,7 +10,7 @@ def test_config_loads(monkeypatch):
     assert config.KIBANA_URL == "http://mock.kibana/"
     assert config.UAA_AUTH_URL == "http://uaa.mock/authorize"
     assert config.UAA_TOKEN_URL == "http://uaa.mock/token"
-    assert config.CF_API_URL == "http://cf.mock/"
+    assert config.CF_API_URL == "http://mock.cf/"
     assert config.UAA_CLIENT_ID == "EXAMPLE"
     assert config.UAA_CLIENT_SECRET == "example"
     assert config.SECRET_KEY == "CHANGEME"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -8,8 +8,8 @@ def test_config_loads(monkeypatch):
     assert config.DEBUG
     assert config.TESTING
     assert config.KIBANA_URL == "http://mock.kibana/"
-    assert config.UAA_AUTH_URL == "http://uaa.mock/authorize"
-    assert config.UAA_TOKEN_URL == "http://uaa.mock/token"
+    assert config.UAA_AUTH_URL == "http://mock.uaa/authorize"
+    assert config.UAA_TOKEN_URL == "http://mock.uaa/token"
     assert config.CF_API_URL == "http://mock.cf/"
     assert config.UAA_CLIENT_ID == "EXAMPLE"
     assert config.UAA_CLIENT_SECRET == "example"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -35,6 +35,7 @@ def test_local_config(monkeypatch, kibana_url):
     monkeypatch.setenv("KIBANA_URL", kibana_url)
     monkeypatch.setenv("CF_API_URL", "https://api.example.com/")
     monkeypatch.setenv("UAA_AUTH_URL", "https://uaa.example.com/authorize")
+    monkeypatch.setenv("UAA_BASE_URL", "https://uaa.example.com/")
     monkeypatch.setenv("UAA_TOKEN_URL", "https://uaa.example.com/token")
     monkeypatch.setenv("UAA_CLIENT_ID", "feedabee")
     monkeypatch.setenv("UAA_CLIENT_SECRET", "CHANGEME")
@@ -46,6 +47,7 @@ def test_local_config(monkeypatch, kibana_url):
     assert config.DEBUG
     assert config.TESTING
     assert config.UAA_AUTH_URL == "https://uaa.example.com/authorize"
+    assert config.UAA_BASE_URL == "https://uaa.example.com/"
     assert config.UAA_TOKEN_URL == "https://uaa.example.com/token"
     assert config.UAA_CLIENT_ID == "feedabee"
     assert config.UAA_CLIENT_SECRET == "CHANGEME"
@@ -62,6 +64,7 @@ def test_prod_config(monkeypatch, kibana_url):
     monkeypatch.setenv("PORT", "8888")
     monkeypatch.setenv("KIBANA_URL", kibana_url)
     monkeypatch.setenv("UAA_AUTH_URL", "https://uaa.example.com/authorize")
+    monkeypatch.setenv("UAA_BASE_URL", "https://uaa.example.com/")
     monkeypatch.setenv("UAA_TOKEN_URL", "https://uaa.example.com/token")
     monkeypatch.setenv("CF_API_URL", "https://api.example.com/")
     monkeypatch.setenv("UAA_CLIENT_ID", "feedabee")
@@ -74,6 +77,7 @@ def test_prod_config(monkeypatch, kibana_url):
     assert not config.DEBUG
     assert not config.TESTING
     assert config.UAA_AUTH_URL == "https://uaa.example.com/authorize"
+    assert config.UAA_BASE_URL == "https://uaa.example.com/"
     assert config.UAA_TOKEN_URL == "https://uaa.example.com/token"
     assert config.UAA_CLIENT_ID == "feedabee"
     assert config.UAA_CLIENT_SECRET == "CHANGEME"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -7,10 +7,10 @@ def test_config_loads(monkeypatch):
     config = config_from_env()
     assert config.DEBUG
     assert config.TESTING
-    assert config.KIBANA_URL == "mock://kibana/"
-    assert config.UAA_AUTH_URL == "mock://uaa/authorize"
-    assert config.UAA_TOKEN_URL == "mock://uaa/token"
-    assert config.CF_API_URL == "mock://cf/"
+    assert config.KIBANA_URL == "http://mock.kibana/"
+    assert config.UAA_AUTH_URL == "http://uaa.mock/authorize"
+    assert config.UAA_TOKEN_URL == "http://uaa.mock/token"
+    assert config.CF_API_URL == "http://cf.mock/"
     assert config.UAA_CLIENT_ID == "EXAMPLE"
     assert config.UAA_CLIENT_SECRET == "example"
     assert config.SECRET_KEY == "CHANGEME"

--- a/tests/unit/test_headers.py
+++ b/tests/unit/test_headers.py
@@ -1,5 +1,6 @@
 from kibana_cf_auth_proxy.headers import list_to_ext_header
 
+
 def test_spaces_to_header():
     header = list_to_ext_header(["foo"])
     assert header == r'"foo"'

--- a/tests/unit/test_headers.py
+++ b/tests/unit/test_headers.py
@@ -1,6 +1,4 @@
 from kibana_cf_auth_proxy.headers import list_to_ext_header
-import pytest
-
 
 def test_spaces_to_header():
     header = list_to_ext_header(["foo"])

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -5,9 +5,13 @@ from kibana_cf_auth_proxy import proxy
 
 def test_proxy_returns_200():
     with requests_mock.Mocker() as m:
-        m.get("mock://kibana/world", text="hello")
+        m.get("http://mock.kibana/world", text="hello")
         response = proxy.proxy_request(
-            "mock://kibana/world", {"user-agent": "special-user-agent"}, None, {}, "GET"
+            "http://mock.kibana/world",
+            {"user-agent": "special-user-agent"},
+            None,
+            {},
+            "GET",
         )
     assert response.data.decode("utf-8") == "hello"
     assert (
@@ -18,12 +22,12 @@ def test_proxy_returns_200():
 def test_proxy_works_with_post():
     with requests_mock.Mocker() as m:
         m.post(
-            "mock://kibana/world",
+            "http://mock.kibana/world",
             text='{"accepted": true}',
             headers={"content-type": "application/json"},
         )
         response = proxy.proxy_request(
-            "mock://kibana/world",
+            "http://mock.kibana/world",
             {"user-agent": "special-user-agent", "content-type": "application/json"},
             '{"foo": "bar"}',
             {},

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -1,14 +1,18 @@
 import requests_mock
-
 from kibana_cf_auth_proxy import uaa
 
-
-def test_gets_user_groups(uaa_user_groups_response):
+def test_user_is_admin(uaa_user_is_admin_response):
     with requests_mock.Mocker() as m:
         m.get(
             "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
-            text=uaa_user_groups_response,
+            text=uaa_user_is_admin_response,
         )
-        assert sorted(uaa.get_user_groups("a-user-id", "a-token")) == sorted(
-            ["cloud_controller.admin", "network.admin"]
+        assert uaa.is_user_cf_admin('a-user-id', 'a-token') is True
+
+def test_user_is_not_admin(uaa_user_is_not_admin_response):
+    with requests_mock.Mocker() as m:
+        m.get(
+            "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
+            text=uaa_user_is_not_admin_response,
         )
+        assert not uaa.is_user_cf_admin('a-user-id', 'a-token')

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -10,6 +10,7 @@ def test_user_is_admin(uaa_user_is_admin_response):
         )
         isAdmin = uaa.is_user_cf_admin("a-user-id", "a-token")
         assert isAdmin
+        assert m.last_request._request.headers["Authorization"] == "Bearer a-token"
 
 
 def test_user_is_not_admin(uaa_user_is_not_admin_response):
@@ -20,3 +21,4 @@ def test_user_is_not_admin(uaa_user_is_not_admin_response):
         )
         isAdmin = uaa.is_user_cf_admin("a-user-id", "a-token")
         assert not isAdmin
+        assert m.last_request._request.headers["Authorization"] == "Bearer a-token"

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -5,16 +5,18 @@ from kibana_cf_auth_proxy import uaa
 def test_user_is_admin(uaa_user_is_admin_response):
     with requests_mock.Mocker() as m:
         m.get(
-            "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
+            "http://mock.uaa/Users/a-user-id",
             text=uaa_user_is_admin_response,
         )
-        assert uaa.is_user_cf_admin("a-user-id", "a-token") is True
+        isAdmin = uaa.is_user_cf_admin("a-user-id", "a-token")
+        assert isAdmin
 
 
 def test_user_is_not_admin(uaa_user_is_not_admin_response):
     with requests_mock.Mocker() as m:
         m.get(
-            "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
+            "http://mock.uaa/Users/a-user-id",
             text=uaa_user_is_not_admin_response,
         )
-        assert not uaa.is_user_cf_admin("a-user-id", "a-token")
+        isAdmin = uaa.is_user_cf_admin("a-user-id", "a-token")
+        assert not isAdmin

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -1,0 +1,13 @@
+import requests_mock
+
+from kibana_cf_auth_proxy import uaa
+
+def test_gets_groups(simple_users_response):
+    with requests_mock.Mocker() as m:
+        m.get(
+            "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
+            text=simple_users_response,
+        )
+        assert sorted(uaa.get_user_groups("a-user-id", "a_token")) == sorted(
+            ["cloud_controller.admin"]
+        )

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -2,11 +2,11 @@ import requests_mock
 
 from kibana_cf_auth_proxy import uaa
 
-def test_gets_groups(simple_users_response):
+def test_gets_user_groups(uaa_user_groups_response):
     with requests_mock.Mocker() as m:
         m.get(
             "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
-            text=simple_users_response,
+            text=uaa_user_groups_response,
         )
         assert sorted(uaa.get_user_groups("a-user-id", "a_token")) == sorted(
             ["cloud_controller.admin"]

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -3,29 +3,6 @@ import requests_mock
 
 from kibana_cf_auth_proxy import uaa
 
-def test_gets_client_credentials_token(fake_jwt_token, uaa_user_groups_response):
-    with requests_mock.Mocker() as m:
-        body = {
-            "access_token": fake_jwt_token,
-            "token_type": "bearer",
-            "expires_in": 2000,
-            "scope": "scim.read",
-            "jti": "idk",
-        }
-        m.post(
-            "mock://uaa/token",
-            # additional_matcher=check_token_body,
-            text=json.dumps(body),
-        )
-        m.get(
-            "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
-            text=uaa_user_groups_response,
-        )
-        uaa.get_user_groups("a-user-id")
-        # assert sorted(uaa.get_user_groups("a-user-id")) == sorted(
-        #     ["cloud_controller.admin", "network.admin"]
-        # )
-
 def test_gets_user_groups(uaa_user_groups_response):
     with requests_mock.Mocker() as m:
         m.get(

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -9,5 +9,5 @@ def test_gets_user_groups(uaa_user_groups_response):
             text=uaa_user_groups_response,
         )
         assert sorted(uaa.get_user_groups("a-user-id", "a_token")) == sorted(
-            ["cloud_controller.admin"]
+            ["cloud_controller.admin", "network.admin"]
         )

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -2,6 +2,7 @@ import requests_mock
 
 from kibana_cf_auth_proxy import uaa
 
+
 def test_gets_user_groups(uaa_user_groups_response):
     with requests_mock.Mocker() as m:
         m.get(

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -1,6 +1,30 @@
+import json
 import requests_mock
 
 from kibana_cf_auth_proxy import uaa
+
+def test_gets_client_credentials_token(fake_jwt_token, uaa_user_groups_response):
+    with requests_mock.Mocker() as m:
+        body = {
+            "access_token": fake_jwt_token,
+            "token_type": "bearer",
+            "expires_in": 2000,
+            "scope": "scim.read",
+            "jti": "idk",
+        }
+        m.post(
+            "mock://uaa/token",
+            # additional_matcher=check_token_body,
+            text=json.dumps(body),
+        )
+        m.get(
+            "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
+            text=uaa_user_groups_response,
+        )
+        uaa.get_user_groups("a-user-id")
+        # assert sorted(uaa.get_user_groups("a-user-id")) == sorted(
+        #     ["cloud_controller.admin", "network.admin"]
+        # )
 
 def test_gets_user_groups(uaa_user_groups_response):
     with requests_mock.Mocker() as m:

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -1,13 +1,15 @@
 import requests_mock
 from kibana_cf_auth_proxy import uaa
 
+
 def test_user_is_admin(uaa_user_is_admin_response):
     with requests_mock.Mocker() as m:
         m.get(
             "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
             text=uaa_user_is_admin_response,
         )
-        assert uaa.is_user_cf_admin('a-user-id', 'a-token') is True
+        assert uaa.is_user_cf_admin("a-user-id", "a-token") is True
+
 
 def test_user_is_not_admin(uaa_user_is_not_admin_response):
     with requests_mock.Mocker() as m:
@@ -15,4 +17,4 @@ def test_user_is_not_admin(uaa_user_is_not_admin_response):
             "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
             text=uaa_user_is_not_admin_response,
         )
-        assert not uaa.is_user_cf_admin('a-user-id', 'a-token')
+        assert not uaa.is_user_cf_admin("a-user-id", "a-token")

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -1,4 +1,3 @@
-import json
 import requests_mock
 
 from kibana_cf_auth_proxy import uaa

--- a/tests/unit/test_uaa.py
+++ b/tests/unit/test_uaa.py
@@ -9,6 +9,6 @@ def test_gets_user_groups(uaa_user_groups_response):
             "mock://uaa/Users?attributes=groups&filter=id eq 'a-user-id'",
             text=uaa_user_groups_response,
         )
-        assert sorted(uaa.get_user_groups("a-user-id", "a_token")) == sorted(
+        assert sorted(uaa.get_user_groups("a-user-id", "a-token")) == sorted(
             ["cloud_controller.admin", "network.admin"]
         )


### PR DESCRIPTION
Closes #4 

## Changes proposed in this pull request:

- Add logic to get a client credentials token from UAA
- Add logic to fetch all of the user's groups from UAA
- Add logic to set `header['x-proxy-roles'] = "admin"` if user is a CF admin
- Remove UAA_TOKEN_URL env var in favor of UAA_BASE_URL 
- Add/update unit tests

## Security considerations

There may be security considerations depending on the soundness of the implementation. For example, are we leaving any holes in our authentication based on the changes in the PR? I think the answer is "no", but a second opinion is necessary.
